### PR TITLE
Adding support for multi-fingerprint IMAP servers

### DIFF
--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -149,7 +149,7 @@ class WrappedIMAP4_SSL(UsefulIMAPMixIn, IMAP4_SSL):
         if (self._fingerprint or not self.ca_certs):
             # compare fingerprints
             fingerprint = sha1(self.sock.getpeercert(True)).hexdigest()
-            if fingerprint != self._fingerprint:
+            if self._fingerprint == None or not any(fingerprint in s for s in self._fingerprint.split()):
                 raise OfflineImapError("Server SSL fingerprint '%s' for hostnam"
                       "e '%s' does not match configured fingerprint. Please ver"
                       "ify and set 'cert_fingerprint' accordingly if not set ye"


### PR DESCRIPTION
For a strange reason imap.gmail.com is distributing randomly two different SSL certificates (all validated by the Google Internet Authority) which makes that Offlineimap refuses the certificate half the time.

For your information, current fingerprints for imap.gmail.com are:
- `f3043dd689a2e7dddfbef82703a6c65ea9b634c1`
- `6d1b5b5ee0180ab493b71d3b94534b5ab937d042`

In .offlineimaprc, separate each fingerprint by a space in cert_fingerprint like this:
`cert_fingerprint = f3043dd689a2e7dddfbef82703a6c65ea9b634c1 6d1b5b5ee0180ab493b71d3b94534b5ab937d042`
