### PR TITLE
Make SIGHUP singal handler equivalent to SIGTERM and SIGINT.

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -308,7 +308,8 @@ SAFE CONNECTION GUARANTEEING THE AUTHENTICITY OF YOUR IMAP SERVER!
 UNIX Signals
 ============
 
-OfflineImap listens to the unix signals SIGUSR1 and SIGUSR2.
+OfflineImap listens to the unix signals SIGUSR1, SIGUSR2, SIGTERM,
+SIGINT, SIGHUP:
 
 If sent a SIGUSR1 it will abort any current (or next future) sleep of all
 accounts that are configured to "autorefresh". In effect, this will trigger a
@@ -318,6 +319,12 @@ If sent a SIGUSR2, it will stop "autorefresh mode" for all accounts. That is,
 accounts will abort any current sleep and will exit after a currently running
 synchronization has finished. This signal can be used to gracefully exit out of
 a running offlineimap "daemon".
+
+SIGTERM, SIGINT, SIGHUP are all treated to gracefully terminate as
+soon as possible. This means it will finish syncing the current folder
+in each account, close keep alive connections, remove locks on the
+accounts and exit. It may take up to 10 seconds, if autorefresh option
+is used.
 
 Folder filtering and nametrans
 ==============================

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -329,14 +329,14 @@ class OfflineImap:
                     syncaccounts.append(account)
 
             def sig_handler(sig, frame):
-                if sig == signal.SIGUSR1 or sig == signal.SIGHUP:
+                if sig == signal.SIGUSR1:
                     # tell each account to stop sleeping
                     accounts.Account.set_abort_event(self.config, 1)
                 elif sig == signal.SIGUSR2:
                     # tell each account to stop looping
                     getglobalui().warn("Terminating after this sync...")
                     accounts.Account.set_abort_event(self.config, 2)
-                elif sig == signal.SIGTERM or sig == signal.SIGINT:
+                elif sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
                     # tell each account to ABORT ASAP (ctrl-c)
                     getglobalui().warn("Terminating NOW (this may "\
                                        "take a few seconds)...")


### PR DESCRIPTION
offlineimap has several frontends that encourage running it from a
terminal under an X session. When X session closes for a system
shutdown, the terminals exit, after sending SIGHUP to their children.

Previously SIGHUP was treated to be equivalent to SIGUSR1, i.e. wake
up and sync all accounts. This causes delays during shutdown.

According to Wikipedia [0], SIGHUP has been repurposed from a
historical meaning to one of:
- re-read configuration files, or reinitialize (e.g. Apache, sendmail)
- controlling pseudo or virtual terminal has been closed

I believe second meaning is more appropriate for offlineimap, and
hence this patch makes SIGHUP to be handled in the same way SIGTERM
and SIGINT are handled.

This patch also adds documentation of the current handling of
SIGTERM/SIGINT/SIGHUP signals.

[0] http://en.wikipedia.org/wiki/SIGHUP

Debian-Bug: http://bugs.debian.org/670120
Reported-By: Steve Langasek steve.langasek@canonical.com
Signed-off-by: Dmitrijs Ledkovs xnox@debian.org
