### PR TITLE
Config typos fix

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -17,9 +17,9 @@
 # trashfolder: %(gmailtrashfolder)s
 #
 # [DEFAULT]
-# gmailtrashfolder = [Google Mail]/Papierkorb
+# gmailtrashfolder = [Gmail]/Papierkorb
 #
-# would set the trashfolder setting for your German gmail accounts.
+# would set the trashfolder setting for your German Gmail accounts.
 
 # NOTE2: This implies that any '%' needs to be encoded as '%%'
 
@@ -218,7 +218,7 @@ remoterepository = RemoteExample
 # messages (e.g. those with large attachments etc).  If you do this it
 # will appear to offlineimap that these messages do not exist at all.  They
 # will not be copied, have flags changed etc.  For this to work on an IMAP
-# server the server must have server side search enabled.  This works with gmail
+# server the server must have server side search enabled.  This works with Gmail
 # and most imap servers (e.g. cyrus etc)
 # The maximum size should be specified in bytes - e.g. 2000000 for approx 2MB
 
@@ -551,11 +551,11 @@ remoteuser = username@gmail.com
 # The trash folder name may be different from [Gmail]/Trash
 # for example on German Gmail, this setting should be
 #
-# trashfolder = [Google Mail]/Papierkorb
+# trashfolder = [Gmail]/Papierkorb
 #
 # The same is valid for the spam folder
 #
-# spamfolder = [Google Mail]/Spam
+# spamfolder = [Gmail]/Spam
 
 # Enable 1-way synchronization. See above for explanation.
 #


### PR DESCRIPTION
Hi,

I've fixed a few typos in the config file.
I'm not a 100% sure on the Google Mail -> Gmail change, but I got it confirmed with an Austrian user, but I hope more people will be able to confirm this.
According to Google Gmail is known as Google Mail in both Germany and Austria.

Kind regards,

Bart
