### PR TITLE
Allow authentication on a tunnel connection

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -54,7 +54,7 @@ class IMAPServer:
         self.config = repos.getconfig()
         self.tunnel = repos.getpreauthtunnel()
         self.usessl = repos.getssl()
-        self.username = None if self.tunnel else repos.getuser()
+        self.username = repos.getuser()
         self.password = None
         self.passworderror = None
         self.goodpassword = None
@@ -219,7 +219,7 @@ class IMAPServer:
                     imapobj = imaplibutil.WrappedIMAP4(self.hostname, self.port,
                                                        timeout=socket.getdefaulttimeout())
 
-                if not self.tunnel:
+                if not self.tunnel or self.username:
                     try:
                         # Try GSSAPI and continue if it fails
                         if 'AUTH=GSSAPI' in imapobj.capabilities and have_gss:


### PR DESCRIPTION
It's nice to set up an ssh tunnel command which simply forwards an IMAP tcp port, e.g. with ssh's "-W" flag. In this case, though, the tunnelled connection still requires authentication.

mbsync / isync support this use case, and this commit allows offlineimap to do the same.

In short, when a `tunnel` command is present, the presence of a `remoteuser` value will cause authentication to take place on the tunnel. (This generally requires also that `remotehost` is set, in order for the user's password to be looked up in .netrc.)

The downside of this change is that to use an unauthenticated tunnel (as all existing configured tunnels will be) the user must presumably omit the remoteuser key, and so some users may need to adjust their configuration files accordingly.

Example configuration:

```
[Repository Remote]
type = IMAP
preauthtunnel = ssh -C -W localhost:143 mail.example.com
remotehost = mail.example.com
remoteuser = user@example.com
```
