### PR TITLE
mbnames: Allow custom sorting of mailboxes

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,9 @@ ChangeLog
 WIP (add new stuff for the next release)
 ========================================
 
+* Allow mbnames output to be sorted by a custom sort key by specifying a
+  'sortkey' function in the [mbnames] section of the config.
+
 OfflineIMAP v6.5.5-rc1 (2012-09-05)
 ===================================
 

--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -145,6 +145,18 @@ footer = "\n"
 #
 # Note that this filter can be used only to further restrict mbnames
 # to a subset of folders that pass the account's folderfilter.
+#
+# You can customize the order in which mailbox names are listed in the
+# generated file by specifying a sortkey, which takes a single dict
+# argument containing the accountname and foldername. The sortkey will
+# be called once for each mailbox, and should return a suitable sort
+# key that defines this mailbox' position in the custom ordering.
+# This is useful with e.g. Mutt-sidebar, which uses the mailbox order
+# from the generated file when listing mailboxes in the sidebar.
+# If sortkey is not given, we default to alphabetical sorting of
+# mailboxes, equivalent to this:
+#
+# sortkey = lambda d: (d['accountname'], d['foldername'])
 
 
 ##################################################

--- a/offlineimap/mbnames.py
+++ b/offlineimap/mbnames.py
@@ -58,17 +58,21 @@ def genmbnames():
         if config.has_option("mbnames", "folderfilter"):
             folderfilter = localeval.eval(config.get("mbnames", "folderfilter"),
                                           {'re': re})
+        mb_sort_key = lambda d: (d['accountname'], d['foldername'])
+        if config.has_option("mbnames", "sortkey"):
+            mb_sort_key = localeval.eval(config.get("mbnames", "sortkey"),
+                                         {'re': re})
         itemlist = []
         for accountname in boxes.keys():
             for foldername in boxes[accountname]:
                 if folderfilter(accountname, foldername):
-                    itemlist.append(config.get("mbnames", "peritem", raw=1) % \
-                                    {'accountname': accountname,
+                    itemlist.append({'accountname': accountname,
                                      'foldername': foldername})
+        itemlist.sort(key = mb_sort_key)
+        format_string = config.get("mbnames", "peritem", raw=1)
+        itemlist = [format_string % d for d in itemlist]
         file.write(localeval.eval(config.get("mbnames", "sep")).join(itemlist))
         file.write(localeval.eval(config.get("mbnames", "footer")))
         file.close()
     finally:
         mblock.release()
-    
-    


### PR DESCRIPTION
Just scratching my own itch by fixing the sorting of mailboxes in mutt-sidebar.
