### PR TITLE
Execute `postsynchook` after IDLE-Sync

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -511,6 +511,8 @@ class IdleThread(object):
         remotefolder = remoterepos.getfolder(self.folder)
         offlineimap.accounts.syncfolder(account, remotefolder, quick=False)
         ui = getglobalui()
+        hook = account.getconf('postsynchook', '')
+        account.callhook(hook)
         ui.unregisterthread(currentThread()) #syncfolder registered the thread
 
     def idle(self):


### PR DESCRIPTION
The hook should be executed after every synchronization, i.e. also after Imap-IDLE-induced sync, not just after the full sync.
