### PR TITLE
Allow setting IMAP servers' SSL version

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -325,6 +325,13 @@ ssl = yes
 
 #cert_fingerprint = <SHA1_of_server_certificate_here>
 
+# SSL version (optional)
+# It is best to leave this unset, in which case the correct version will be
+# automatically detected. In rare cases, it may be necessary to specify a
+# particular version from: tls1, ssl2, ssl3, ssl23 (SSLv2 or SSLv3)
+
+# sslversion = ssl23
+
 # Specify the port.  If not specified, use a default port.
 # remoteport = 993
 

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -65,6 +65,7 @@ class IMAPServer:
         self.sslclientcert = repos.getsslclientcert()
         self.sslclientkey = repos.getsslclientkey()
         self.sslcacertfile = repos.getsslcacertfile()
+        self.sslversion = repos.getsslversion()
         if self.sslcacertfile is None:
             self.verifycert = None # disable cert verification
         self.delim = None
@@ -211,6 +212,7 @@ class IMAPServer:
                                                            self.sslclientcert,
                                                            self.sslcacertfile,
                                                            self.verifycert,
+                                                           self.sslversion,
                                                            timeout=socket.getdefaulttimeout(),
                                                            fingerprint=fingerprint
                                                            )

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -172,6 +172,9 @@ class IMAPRepository(BaseRepository):
                                 % (self.name, cacertfile))
         return cacertfile
 
+    def getsslversion(self):
+        return self.getconf('ssl_version', None)
+
     def get_ssl_fingerprint(self):
         return self.getconf('cert_fingerprint', None)
 


### PR DESCRIPTION
We now allow setting the SSL version used when connecting to IMAPS servers, and
do so via the `ssl_version` configuration option. We default to the current
practice (letting python's "ssl" library automatically detect the correct
version). There are however rare cases where one must specify the version to
use.

Signed-off-by: Ryan Kavanagh rak@debian.org
