### PR TITLE
Make authentication mechanisms configurable

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -17,6 +17,7 @@ WIP (add new stuff for the next release)
 * Allow mbnames output to be sorted by a custom sort key by specifying
   a 'sort_keyfunc' function in the [mbnames] section of the config.
 * Support SASL PLAIN authentication method.  (Andreas Mack)
+* Make authentication mechanisms configurable (Andreas Mack)
 
 OfflineIMAP v6.5.5-rc1 (2012-09-05)
 ===================================

--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -365,6 +365,15 @@ remoteuser = username
 #
 # remote_identity = authzuser
 
+# Specify which authentication/authorization mechanisms to try. If you want
+# to use remote_identity above, you don't want to use a mechanism that
+# doesn't support a separate authorization id like LOGIN. The follow values
+# are supported: PLAIN, LOGIN, CRAM-MD5, GSSAPI. The default is to try all
+# mechanisms in the following
+order: GSSAPI, CRAM-MD5, PLAIN, LOGIN
+#
+# auth_mechanisms = PLAIN
+
 # There are six ways to specify the password for the IMAP server:
 #
 # 1. No password at all specified in the config file.

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -56,6 +56,7 @@ class IMAPServer:
         self.usessl = repos.getssl()
         self.username = None if self.tunnel else repos.getuser()
         self.user_identity = repos.get_remote_identity()
+        self.authmechs = repos.get_auth_mechanisms()
         self.password = None
         self.passworderror = None
         self.goodpassword = None
@@ -199,7 +200,7 @@ class IMAPServer:
         tried_to_authn = False
 
         # Try GSSAPI and continue if it fails
-        if 'AUTH=GSSAPI' in imapobj.capabilities and have_gss:
+        if 'AUTH=GSSAPI' in imapobj.capabilities and have_gss and "GSSAPI" in self.authmechs:
             self.connectionlock.acquire()
             self.ui.debug('imap', 'Attempting GSSAPI authentication')
             tried_to_authn = True
@@ -232,9 +233,9 @@ class IMAPServer:
                   "TLS connection: %s" % str(e),
                   OfflineImapError.ERROR.REPO)
 
-	# Hashed authenticators come first: they don't reveal
-	# passwords.
-        if 'AUTH=CRAM-MD5' in imapobj.capabilities:
+    # Hashed authenticators come first: they don't reveal
+    # passwords.
+        if 'AUTH=CRAM-MD5' in imapobj.capabilities and "CRAM-MD5" in self.authmechs:
             tried_to_authn = True
             self.ui.debug('imap', 'Attempting '
               'CRAM-MD5 authentication')
@@ -246,7 +247,7 @@ class IMAPServer:
                 exc_stack.append(('CRAM-MD5', e))
 
         # Try plaintext authenticators.
-        if 'AUTH=PLAIN' in imapobj.capabilities:
+        if 'AUTH=PLAIN' in imapobj.capabilities and "PLAIN" in self.authmechs:
             tried_to_authn = True
             self.ui.debug('imap', 'Attempting '
               'PLAIN authentication')
@@ -259,21 +260,22 @@ class IMAPServer:
 
         # Last resort: use LOGIN command,
         # unless LOGINDISABLED is advertized (RFC 2595)
-        if 'LOGINDISABLED' in imapobj.capabilities:
-            e = OfflineImapError("IMAP LOGIN is "
-              "disabled by server.  Need to use SSL?",
-               OfflineImapError.ERROR.REPO)
-            exc_stack.append(('IMAP LOGIN', e))
-        else:
-            tried_to_authn = True
-            self.ui.debug('imap', 'Attempting '
-              'IMAP LOGIN authentication')
-            try:
-                self.loginauth(imapobj)
-                return
-            except imapobj.error as e:
-                self.ui.warn('IMAP LOGIN authentication failed: %s' % e)
+        if 'LOGIN' in self.authmechs:
+            if 'LOGINDISABLED' in imapobj.capabilities:
+                e = OfflineImapError("IMAP LOGIN is "
+                  "disabled by server.  Need to use SSL?",
+                   OfflineImapError.ERROR.REPO)
                 exc_stack.append(('IMAP LOGIN', e))
+            else:
+                tried_to_authn = True
+                self.ui.debug('imap', 'Attempting '
+                  'IMAP LOGIN authentication')
+                try:
+                    self.loginauth(imapobj)
+                    return
+                except imapobj.error as e:
+                    self.ui.warn('IMAP LOGIN authentication failed: %s' % e)
+                    exc_stack.append(('IMAP LOGIN', e))
 
         if len(exc_stack):
             msg = "\n\t".join(map(

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -126,6 +126,28 @@ class IMAPRepository(BaseRepository):
 
         return self.getconf('remote_identity', default=None)
 
+    def get_auth_mechanisms(self):
+        line = self.getconf('auth_mechanisms', default=None)
+        prefab = [ 'PLAIN','CRAM-MD5', 'LOGIN','GSSAPI']
+        if line == None or len(line) == 0:
+            self.ui.debug('imap', "Using prefab %s" % prefab)
+            return prefab
+        smechs=line.split(",")
+        mechs=list()
+
+        for mech in smechs:
+            if mech not in prefab:
+                raise OfflineImapError("auth mechanism option for repository "\
+                                       "'%s' unknown or not supported:\n%s" % (self, mech),
+                                       OfflineImapError.ERROR.REPO)
+            mechs.append(mech)
+        if len(mechs) < 1:
+            raise OfflineImapError("no auth mechanism for repository "\
+                                       "'%s' unknown found:\n" % (self),
+                                       OfflineImapError.ERROR.REPO)
+        self.ui.debug('imap', "Using mechs %s" % mechs)    
+        return mechs
+
 
     def getuser(self):
         user = None


### PR DESCRIPTION
Not all mechanisms support separate authorization like CRAM-MD5. If remote_identity is given and the server supports CRAM-MD5, then offlineimap will connect without requesting the authorization id. 

The first commit is the patch for adding PLAIN support from Eygene, the second commit is the implementation.
