### PR TITLE
Optional TLS

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -73,6 +73,7 @@ class IMAPServer:
         self.goodpassword = None
 
         self.usessl = repos.getssl()
+	self.usetls = repos.gettls()
         self.hostname = \
           None if self.preauth_tunnel else repos.gethost()
         self.port = repos.getport()
@@ -197,7 +198,7 @@ class IMAPServer:
 
 
     def _start_tls(self, imapobj):
-        if 'STARTTLS' in imapobj.capabilities and not self.usessl:
+        if 'STARTTLS' in imapobj.capabilities and not self.usessl and self.usetls:
             self.ui.debug('imap', 'Using STARTTLS connection')
             try:
                 imapobj.starttls()

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -73,7 +73,7 @@ class IMAPServer:
         self.goodpassword = None
 
         self.usessl = repos.getssl()
-	self.usetls = repos.gettls()
+        self.usetls = repos.gettls()
         self.hostname = \
           None if self.preauth_tunnel else repos.gethost()
         self.port = repos.getport()

--- a/offlineimap/repository/Gmail.py
+++ b/offlineimap/repository/Gmail.py
@@ -55,7 +55,7 @@ class GmailRepository(IMAPRepository):
         return 1
 
     def gettls(self):
-	return 1
+        return 1
 
     def getpreauthtunnel(self):
         return None

--- a/offlineimap/repository/Gmail.py
+++ b/offlineimap/repository/Gmail.py
@@ -54,6 +54,9 @@ class GmailRepository(IMAPRepository):
     def getssl(self):
         return 1
 
+    def gettls(self):
+	return 1
+
     def getpreauthtunnel(self):
         return None
 

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -193,7 +193,7 @@ class IMAPRepository(BaseRepository):
         return self.getconfboolean('ssl', 0)
 
     def gettls(self):
-        return self.getconfboolean('tls', 0)
+        return self.getconfboolean('tls', True)
 
     def getsslclientcert(self):
         return self.getconf('sslclientcert', None)

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -192,6 +192,9 @@ class IMAPRepository(BaseRepository):
     def getssl(self):
         return self.getconfboolean('ssl', 0)
 
+    def gettls(self):
+        return self.getconfboolean('tls', 0)
+
     def getsslclientcert(self):
         return self.getconf('sslclientcert', None)
 


### PR DESCRIPTION
I have just adapt the code to fulfil this old debian patch I've found on internet written by Kapil Hari Paranjape <kapil@imsc.res.in>. You can find more information in this link <http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=681494>

>I need to connect to a badly configured server that advertises STARTTLS
>but is not properly configured for it :(
>
>So I created an option 'tls' which allows me to disable the use of
>STARTTLS for this server.

Hope it helps
