### PR TITLE
fix log output when running with -u machineui -q

### DIFF
--- a/offlineimap/ui/Machine.py
+++ b/offlineimap/ui/Machine.py
@@ -29,9 +29,9 @@ protocol = '7.0.0'
 class MachineLogFormatter(logging.Formatter):
     """urlencodes any outputted line, to avoid multi-line output"""
     def format(self, record):
-        # urlencode the "mesg" attribute and append to regular line...
+        # urlencode the "msg" attribute and append to regular line...
         line = super(MachineLogFormatter, self).format(record)
-        return line + urlencode([('', record.mesg)])[1:]
+        return line + urlencode([('', record.msg)])[1:]
 
 class MachineUI(UIBase):
     def __init__(self, config, loglevel = logging.INFO):


### PR DESCRIPTION
Looks like no one's run offlineimap with both -u machineui and -q, at least
in a while. This patch fixes the following:

➜  ~  offlineimap -c ~/testofflineimaprc -u machineui -q
OfflineIMAP 6.5.5
  Licensed under the GNU GPL v2+ (v2 or any later version)
msg:protocol:MainThread7.0.0
msg:initbanner:MainThreadOfflineIMAP+6.5.5%0A++Licensed+under+the+GNU+GPL+v2%2B+%28v2+or+any+later+version%29
msg:registerthread:Account sync personalpersonal
msg:acct:Account sync personalpersonal
msg:connecting:Account sync personalimap.gmail.com%0A993
msg:syncfolders:Account sync personalIMAP%0AMaildir
msg:registerthread:Folder INBOX [acc: personal]personal
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/**init**.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/**init**.py", line 724, in format
    return fmt.format(record)
  File "/home/spang/src/mirrors/offlineimap/offlineimap/ui/Machine.py", line 34, in format
    return line + urlencode([('', record.mesg)])[1:]
AttributeError: 'LogRecord' object has no attribute 'mesg'
Logged from file UIBase.py, line 318
msg:threadExited:MainThreadFolder+INBOX+%5Bacc%3A+personal%5D
msg:unregisterthread:MainThreadFolder+INBOX+%5Bacc%3A+personal%5D
msg:acctdone:Account sync personalpersonal
msg:threadExited:MainThreadAccount+sync+personal
msg:unregisterthread:MainThreadAccount+sync+personal
msg:terminate:MainThread0%0A%0A
