### PR TITLE
Drop caches after having processed folders.

### DIFF
--- a/offlineimap/accounts.py
+++ b/offlineimap/accounts.py
@@ -475,3 +475,7 @@ def syncfolder(account, remotefolder, quick):
         ui.error(e, msg = "ERROR in syncfolder for %s folder %s: %s" % \
                 (account, remotefolder.getvisiblename(),
                  traceback.format_exc()))
+    finally:
+        for folder in ["statusfolder", "localfolder", "remotefolder"]:
+            if folder in locals():
+                locals()[folder].dropmessagelistcache()

--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -189,6 +189,9 @@ class BaseFolder(object):
         memory unless this function is called again."""
         raise NotImplementedException
 
+    def dropmessagelistcache(self):
+        raise NotImplementedException
+
     def getmessagelist(self):
         """Gets the current message list.
         You must call cachemessagelist() before calling this function!"""

--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -199,6 +199,9 @@ class IMAPFolder(BaseFolder):
                 rtime = imaplibutil.Internaldate2epoch(messagestr)
                 self.messagelist[uid] = {'uid': uid, 'flags': flags, 'time': rtime}
 
+    def dropmessagelistcache(self):
+        self.messagelist = None
+
     def getmessagelist(self):
         return self.messagelist
 

--- a/offlineimap/folder/LocalStatus.py
+++ b/offlineimap/folder/LocalStatus.py
@@ -84,6 +84,9 @@ class LocalStatusFolder(BaseFolder):
             self.messagelist[uid] = {'uid': uid, 'flags': flags}
         file.close()
 
+    def dropmessagelistcache(self):
+        self.messagelist = None
+
     def save(self):
         with self.savelock:
             file = open(self.filename + ".tmp", "wt")

--- a/offlineimap/folder/LocalStatusSQLite.py
+++ b/offlineimap/folder/LocalStatusSQLite.py
@@ -175,6 +175,9 @@ class LocalStatusSQLiteFolder(LocalStatusFolder):
                 flags = set(row[1])
                 self.messagelist[row[0]] = {'uid': row[0], 'flags': flags}
 
+    def dropmessagelistcache(self):
+        self.messagelist = None
+
     def save(self):
         #Noop in this backend
         pass

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -208,6 +208,9 @@ class MaildirFolder(BaseFolder):
         if self.messagelist is None:
             self.messagelist = self._scanfolder()
 
+    def dropmessagelistcache(self):
+        self.messagelist = None
+
     def getmessagelist(self):
         return self.messagelist
 

--- a/offlineimap/folder/UIDMaps.py
+++ b/offlineimap/folder/UIDMaps.py
@@ -122,6 +122,9 @@ class MappedIMAPFolder(IMAPFolder):
         finally:
             self.maplock.release()
 
+    def dropmessagelistcache(self):
+        self._mb.dropmessagelistcache()
+
     def uidexists(self, ruid):
         """Checks if the (remote) UID exists in this Folder"""
         # This implementation overrides the one in BaseFolder, as it is


### PR DESCRIPTION
OfflineIMAP retains forever messagelist caches after having processed a folder. This means that memory consumption grows linearly with the number of processed folders. With this commit memory is reclaimed after having finished to process a folder. In my case (about 30 folders) the enhancement is significant, especially when running on lower-end machines.

I didn't perform particularly careful testing for this commit; I just saw it working in my case.