### PR TITLE
Add support for maildir indexes.

### DIFF
--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -33,6 +33,7 @@ except NameError:
     from sets import Set as set
 
 from offlineimap import OfflineImapError
+from offlineimap.index import message_index_for_backend
 
 # Find the UID in a message filename
 re_uidmatch = re.compile(',U=(\d+)')
@@ -65,6 +66,10 @@ class MaildirFolder(BaseFolder):
         self.dofsync = self.config.getdefaultboolean("general", "fsync", True)
         self.root = root
         self.messagelist = None
+
+        index_backend = repository.getconf('index_backend', 'dummy')
+        self.index = message_index_for_backend(index_backend, self)
+
         # check if we should use a different infosep to support Win file systems
         self.wincompatible = self.config.getdefaultboolean(
             "Account "+self.accountname, "maildir-windows-compatible", False)
@@ -330,6 +335,7 @@ class MaildirFolder(BaseFolder):
 
             self.messagelist[uid]['flags'] = flags
             self.messagelist[uid]['filename'] = newfilename
+            self.index.add(os.path.join(self.getfullname(), newfilename))
 
     def change_message_uid(self, uid, new_uid):
         """Change the message from existing uid to new_uid
@@ -374,5 +380,6 @@ class MaildirFolder(BaseFolder):
                 filepath = os.path.join(self.getfullname(), filename)
                 os.unlink(filepath)
             # Yep -- return.
+        self.index.remove(filepath)
         del(self.messagelist[uid])
 

--- a/offlineimap/index.py
+++ b/offlineimap/index.py
@@ -1,0 +1,78 @@
+from subprocess import Popen, PIPE
+import shlex
+
+from offlineimap.ui import getglobalui
+import offlineimap.accounts
+
+class MessageIndex(object):
+    def __init__(self, folder):
+        self.folder = folder
+        self.ui = getglobalui()
+
+    def add(self, message):
+        raise NotImplementedException
+
+    def remove(self, message):
+        raise NotImplementedException
+
+
+class DummyIndex(MessageIndex):
+
+    def add(self, message):
+        pass
+
+    def remove(self, message):
+        pass
+
+
+class MemoryIndex(MessageIndex):
+    def __init__(self, folder):
+        super(MemoryIndex, self).__init__(folder)
+        self.data = set()
+
+    def add(self, message):
+        self.data.add(message)
+
+    def remove(self, message):
+        self.data.remove(message)
+
+
+class HookIndex(MessageIndex):
+    def __init__(self, folder):
+        super(HookIndex, self).__init__(folder)
+        self.add_command = self.folder.repository.getconf('index_add')
+        self.remove_command = self.folder.repository.getconf('index_remove')
+
+    def add(self, message):
+        return self.call(self.add_command, message)
+
+    def remove(self, message):
+        return self.call(self.remove_command, message)
+
+    def call(self, cmd, message):
+        # check for CTRL-C or SIGTERM and run.
+        if offlineimap.accounts.Account.abort_NOW_signal.is_set():
+            return
+        if not cmd:
+            return
+        cmd_list = shlex.split(cmd)
+        cmd_list.append(message)
+        cmd = ' '.join(cmd_list)
+        p = Popen(cmd_list, shell=False,
+                  stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                  close_fds=True)
+        stdout, stderr = p.communicate()
+        self.ui.callhook("Index %s stdout: %s\nHook stderr:%s\n" % (cmd, stdout, stderr))
+        self.ui.callhook("Index %s return code: %d" % (cmd, p.returncode))
+
+
+def message_index_for_backend(backend, account):
+    classes = dict(
+        memory=MemoryIndex,
+        hook=HookIndex,
+        dummy=DummyIndex,
+    )
+    cls = classes.get(backend, None)
+    if cls is None:
+        raise SyntaxError("unsupported index backend: %s" % backend)
+    return cls(account)


### PR DESCRIPTION
After saving updated message flags, Maildir will update a
MessageIndex. Several implementations are provided, though only
HookIndex is of much use at this point. HookIndex is configured with
three new options in a Repository section in the config:

```
index_backend = {hook,dummy,memory}
index_add = {cmd}
index_remove = {cmd}
```

`index_backend` determines which class is used for the index; the
default is `DummyIndex`, which provides no-op implementations of the
basic methods. `index_add` and `index_remove` are used by the
`HookIndex` and determine what commands it executes when saving a new
message in a Maildir. `index_add` and `index_remove` are both invoked as
follows:

```
{index_command} {full_path_to_new_message_file}
```