### PR TITLE
Initial XOAUTH2 implementation

### DIFF
--- a/offlineimap/repository/Gmail.py
+++ b/offlineimap/repository/Gmail.py
@@ -29,6 +29,8 @@ class GmailRepository(IMAPRepository):
     # Gmail IMAP server port
     PORT = 993
 
+    OAUTH2_URL = 'https://accounts.google.com/o/oauth2/token'
+
     def __init__(self, reposname, account):
         """Initialize a GmailRepository object."""
         # Enforce SSL usage
@@ -47,6 +49,18 @@ class GmailRepository(IMAPRepository):
             # nothing was configured, cache and return hardcoded one
             self._host = GmailRepository.HOSTNAME
             return self._host
+
+    def getoauth2_request_url(self):
+        """Return the server name to connect to.
+
+        Gmail implementation first checks for the usual IMAP settings
+        and falls back to imap.gmail.com if not specified."""
+        try:
+            return super(GmailRepository, self).getoauth2_request_url()
+        except OfflineImapError:
+            # nothing was configured, cache and return hardcoded one
+            self._oauth2_request_url = GmailRepository.OAUTH2_URL
+            return self._oauth2_request_url
 
     def getport(self):
         return GmailRepository.PORT


### PR DESCRIPTION
Hi,

Opening this pull request for comments from the community. Not sure at the direction I've taken and would advice on what else to add so this makes it to the master branch.

To use you will need:

1. A Google OAuth2 client registered: https://developers.google.com/accounts/docs/OAuth2Login#registeringyourapp
    - Be sure to change the default project name (under project Settings)
    - You will need from this page:
        - client_id
        - client_secret
2. An email with this client authorized, namely the refresh_token, from performing an authentication. Easiest thing to do is to follow the steps here https://code.google.com/p/google-mail-oauth2-tools/wiki/OAuth2DotPyRunThrough

In your Repository, set the following configuration options:

    [Repository gmail-remote]
    type = Gmail
    remoteuser = <you>@gmail.com
    oauth2_client_id = <your_client_id>
    oauth2_client_secret = <your_client_secret>
    oauth2_refresh_token = <your_refresh_token_for_remoteuser>

Should be ready to rock. This method may work on other IMAPs that support AUTH=XOAUTH2, but I have no server other than Gmail to test on. I've tested that this method also works for Google Apps Gmail accounts.
