### PR TITLE
Fix: Undefined variable 'this' should be 'self'

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -85,7 +85,7 @@ class BaseFolder(object):
         if not self._dynamic_folderfilter:
             return self._sync_this
         else:
-            return this.repository.should_sync_folder(self.ffilter_name)
+            return self.repository.should_sync_folder(self.ffilter_name)
 
     @property
     def utime_from_message(self):


### PR DESCRIPTION
A trivial fix of the following error:

OfflineIMAP 6.5.5
  Licensed under the GNU GPL v2+ (v2 or any later version)
ERROR: Exceptions occurred during the run!
ERROR: While attempting to sync account 'sthu'
  global name 'this' is not defined

Traceback:
  File "/usr/lib64/python2.7/site-packages/offlineimap/accounts.py", line 241, in syncrunner
    self.sync()
  File "/usr/lib64/python2.7/site-packages/offlineimap/accounts.py", line 306, in sync
    remoterepos.sync_folder_structure(localrepos, statusrepos)
  File "/usr/lib64/python2.7/site-packages/offlineimap/repository/Base.py", line 187, in sync_folder_structure
    if src_folder.sync_this and not src_name_t in dst_folders:
  File "/usr/lib64/python2.7/site-packages/offlineimap/folder/Base.py", line 88, in sync_this
    return this.repository.should_sync_folder(self.ffilter_name)
