### PR TITLE
read user from ~/.netrc before reading /etc/netrc

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -170,6 +170,14 @@ class IMAPRepository(BaseRepository):
                 return netrcentry[0]
 
         try:
+            netrcentry = netrc.netrc().authenticators(self.gethost())
+        except IOError as inst:
+            if inst.errno not in (errno.ENOENT, errno.EACCES):
+                raise
+        else:
+            if netrcentry:
+                return netrcentry[0]
+        try:
             netrcentry = netrc.netrc('/etc/netrc').authenticators(self.gethost())
         except IOError as inst:
             if inst.errno not in (errno.ENOENT, errno.EACCES):


### PR DESCRIPTION
The password is read from the user's netrc before reading /etc/netrc, so offlineimap should also be able to use the username of that netrc entry as well.
