### PR TITLE
fix header insertion to respect CRLF line-endings

### DIFF
--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -535,7 +535,8 @@ class IMAPFolder(BaseFolder):
                                                     content)
                     self.ui.debug('imap', 'savemessage: header is: %s: %s' %\
                                       (headername, headervalue))
-                    content = self.addmessageheader(content, headername, headervalue)
+                    content = self.addmessageheader(content, headername, headervalue,
+                                                    linebreak=CRLF)
 
                 if len(content)>200:
                     dbg_output = "%s...%s" % (content[:150], content[-50:])


### PR DESCRIPTION
844ca6b0 badly broke `addmessageheader()` because it changed the content to use CRLF line-endings, so searching for the `\n\n` transition between header and body always failed.  This resulted in mail files with the following structure:

```
X-OfflineIMAP: 3453842182-3083369391\n
\n
Subject: ...\n
From: ...\n
To: ...\n
... other header lines ...\n
\n
body line 1\n
body line 2\n
```

Then MUAs and the IMAP server would treat this as a mail with a single header line and a body which starts with something looking suspiciously like a header.

Improved the docstring to clarify these issues.

**NOTE: I am not sure whether other sub-classes of `BaseFolder` also need `linebreak=CRLF` adding to the `addmessageheader()` call?**
