### PR TITLE
addmessageheader() cosmetic improvements

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -444,6 +444,14 @@ class BaseFolder(object):
         prefix = linebreak
         suffix = ''
         insertionpoint = content.find(linebreak * 2)
+        if insertionpoint == -1:
+            self.ui.debug('', 'addmessageheader: header was missing')
+        else:
+            self.ui.debug('', 'addmessageheader: header ends at %d' % insertionpoint)
+            contextstart = max(0,            insertionpoint - 100)
+            contextend   = min(len(content), insertionpoint + 100)
+            self.ui.debug('', 'addmessageheader: header/body transition context: %s' %
+                          repr(content[contextstart:contextend]))
         if insertionpoint == 0 or insertionpoint == -1:
             prefix = ''
             suffix = linebreak


### PR DESCRIPTION
844ca6b badly broke `addmessageheader()` because it changed the content to use CRLF line-endings, so searching for the `\n\n` transition between header and body always failed.  However unfortunately a fix was pushed to github `master` just as I had finalized my own independent fix and submitted it as #96.  Therefore I'm resubmitting this which hopefully is a "best of breed" merge of the two approaches.
