### PR TITLE
Add the OpenSSL exception

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -348,3 +348,17 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Library General
 Public License instead of this License.
+
+----------------------------------------------------------------
+In addition, as a special exception, the copyright holders give
+permission to link the code of portions of this program with the OpenSSL
+library under certain conditions as described in each individual source
+file, and distribute linked combinations including the two.
+
+You must obey the GNU General Public License in all respects for all of
+the code used other than OpenSSL. If you modify file(s) with this
+exception, you may extend this exception to your version of the file(s),
+but you are not obligated to do so. If you do not wish to do so, delete
+this exception statement from your version. If you delete this exception
+statement from all source files in the program, then also delete it
+here.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ documentation.
 OfflineIMAP does not require additional python dependencies beyond python >=2.6
 (although python-sqlite is strongly recommended).
 
-OfflineIMAP is a Free Software project licensed under the GNU General Public
-License version 2 (or later). You can download it for free, and you can modify
-it. In fact, you are encouraged to contribute to OfflineIMAP.
+OfflineIMAP is a Free Software project licensed under the GNU General
+Public License version 2 (or later) with a special exception that allows
+the OpenSSL library to be used. You can download it for free, and you
+can modify it. In fact, you are encouraged to contribute to OfflineIMAP.
 
 Documentation
 -------------

--- a/offlineimap/__init__.py
+++ b/offlineimap/__init__.py
@@ -8,7 +8,7 @@ __copyright__   = "Copyright 2002-2013 John Goerzen & contributors"
 __author__      = "John Goerzen"
 __author_email__= "john@complete.org"
 __description__ = "Disconnected Universal IMAP Mail Synchronization/Reader Support"
-__license__  = "Licensed under the GNU GPL v2+ (v2 or any later version)"
+__license__  = "Licensed under the GNU GPL v2 or any later version (with an openssl exception)"
 __bigcopyright__ = """%(__productname__)s %(__bigversion__)s
   %(__license__)s""" % locals()
 __homepage__ = "http://offlineimap.org"


### PR DESCRIPTION
The GNU GPL and the OpenSSL license are incompatible. Some distributions
take a hardline stance and do not consider OpenSSL to be a systems library
(which would permit the usage/distribution of OpenSSL) when distributing
apps such as OfflineImap from the same repository. In order to solve these
distributions dilemma, we add the OpenSSL exception to our GNU GPL v2+ license.
This allows for unambiguous use/distribution of our GNU GPL'ed application
with a python linking to openssl.

Consent of all contributors has been requested via email by
Sebastian@SSpaeth.de. With very few exceptions of minor contributions (which
might or might not by copyright-worthy) all past contributors have consented
to adding the OpenSSL exception. None of the replying authors has disagreed
with adding the exception.

The corresponding issues at question:
 https://github.com/OfflineIMAP/offlineimap/issues/104
 Debian bug #747033

Signed-off-by: Sebastian Spaeth Sebastian@SSpaeth.de
