### PR TITLE
Do not keep reloading pyhtonfile, make it stateful

### DIFF
--- a/offlineimap/CustomConfig.py
+++ b/offlineimap/CustomConfig.py
@@ -24,6 +24,10 @@ except ImportError: #python3
 from offlineimap.localeval import LocalEval
 
 class CustomConfigParser(SafeConfigParser):
+    def __init__(self):
+        SafeConfigParser.__init__(self)
+        self.localeval = None
+
     def getdefault(self, section, option, default, *args, **kwargs):
         """Same as config.get, but returns the value of `default`
         if there is no such option specified."""
@@ -91,13 +95,19 @@ class CustomConfigParser(SafeConfigParser):
         return metadatadir
 
     def getlocaleval(self):
+        # We already loaded pythonfile, so return this copy.
+        if self.localeval is not None:
+            return self.localeval
+
         xforms = [os.path.expanduser, os.path.expandvars]
         if self.has_option("general", "pythonfile"):
             path = self.get("general", "pythonfile")
             path = self.apply_xforms(path, xforms)
         else:
             path = None
-        return LocalEval(path)
+
+        self.localeval = LocalEval(path)
+        return self.localeval
 
     def getsectionlist(self, key):
         """Returns a list of sections that start with (str) key + " ".


### PR DESCRIPTION
CustomConfigParser.getlocaleval() loads "pythonfile" at each call.
Besides unnecessary IO, in case that dynamic_folderfilter is true, the
code in "pythonfile" would behave stateless, since it is re-initialized
at each call of getlocaleval(), i.e., at every sync. Fix that by keeping
a singleton copy of localeval in CustomConfigParser after the first call
of getlocaleval().

Application:
In my personal setup, I only check for mail in Junk/ every couple of hours. To realize this I remember the time when folderfilter() was called for "Junk" the last time and only return True if a couple of hours passed by. Without this patch, however, I cannot recall the time of the last check, as the pythonfile is reloaded at each synchronization.
