### PR TITLE
add OpenBSD's ca cert file path

### DIFF
--- a/offlineimap/utils/distro.py
+++ b/offlineimap/utils/distro.py
@@ -13,7 +13,7 @@ import os
 # one that corresponds to the existing file.
 __DEF_OS_LOCATIONS = {
     'freebsd': '/usr/local/share/certs/ca-root-nss.crt',
-    'openbsd': None,
+    'openbsd': '/etc/ssl/cert.pem',
     'netbsd': None,
     'dragonfly': None,
     'darwin': [


### PR DESCRIPTION
/etc/ssl/cert.pem is the path for OpenBSD's trusted ca-bundle for root certificates.
