### PR TITLE
Fix apply_xforms typo

### DIFF
--- a/offlineimap/mbnames.py
+++ b/offlineimap/mbnames.py
@@ -55,7 +55,7 @@ def __genmbnames():
         localeval = config.getlocaleval()
         if not config.getdefaultboolean("mbnames", "enabled", 0):
             return
-        path = config.apply_xform(config.get("mbnames", "filename"), xforms)
+        path = config.apply_xforms(config.get("mbnames", "filename"), xforms)
         file = open(path, "wt")
         file.write(localeval.eval(config.get("mbnames", "header")))
         folderfilter = lambda accountname, foldername: 1


### PR DESCRIPTION
Fixes a bug introduced in e51ed80ecc1830ca3184761ccbfa63cf22cc2d42 since apply_xform (without the 's') doesn't exist.

This threw this error:

```
CustomConfigParser instance has no attribute 'apply_xform'
```
