### PR TITLE
Proxy support

### DIFF
--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -214,7 +214,7 @@ class WrappedIMAP4(UsefulIMAPMixIn, IMAP4):
         if "use_socket" in kwargs:
             self.socket = kwargs['use_socket']
             del kwargs['use_socket']
-        IMAP4.__init__(sekf, *args, **kwargs)
+        IMAP4.__init__(self, *args, **kwargs)
 
 
 def Internaldate2epoch(resp):


### PR DESCRIPTION
Usage notes:

    1. Install PySocks.

    ```
    pip install PySocks
    ```

    2. Added an option line in your account section:

    ```
    [Account Gmail]
    localrepository = Gmail-Local
    remoterepository = Gmail-Remote
    status_backend = sqlite
    proxy = SOCKS5:localhost:9999
    ```

    available proxy types are: SOCKS5, SOCKS4, HTTP

Implementation notes:

I personally removed imaplib2 from this repo before working 
on this feature, and have to do some work around imaplibutil.