### PR TITLE
mbnames: add option to write the file once

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -182,6 +182,9 @@ accounts = Test
 # The header, peritem, sep, and footer are all Python expressions passed
 # through eval, so you can (and must) use Python quoting.
 #
+# The incremental setting controls whether the file is written after each
+# account completes or once all synced accounts are complete.
+#
 # The following hash key are available to the expansion for 'peritem':
 # - accountname: the name of the corresponding account;
 # - foldername: the name of the folder;
@@ -197,6 +200,7 @@ accounts = Test
 #peritem = "+%(accountname)s/%(foldername)s"
 #sep = " "
 #footer = "\n"
+#incremental = yes
 
 
 # This option stands in the [mbnames] section.

--- a/offlineimap/accounts.py
+++ b/offlineimap/accounts.py
@@ -359,7 +359,7 @@ class SyncableAccount(Account):
                 thr.join()
             # Write out mailbox names if required and not in dry-run mode
             if not self.dryrun:
-                mbnames.write()
+                mbnames.write(False)
             localrepos.forgetfolders()
             remoterepos.forgetfolders()
         except:

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -334,6 +334,10 @@ class OfflineImap:
                                            'config': self.config})
                 t.start()
                 threadutil.exitnotifymonitorloop(threadutil.threadexited)
+
+            if not options.dryrun:
+                offlineimap.mbnames.write(True)
+
             self.ui.terminate()
         except (SystemExit):
             raise

--- a/offlineimap/mbnames.py
+++ b/offlineimap/mbnames.py
@@ -38,7 +38,17 @@ def add(accountname, foldername, localfolders):
     if not foldername in boxes[accountname]:
         boxes[accountname].append(foldername)
 
-def write():
+def write(allcomplete):
+    incremental = config.getdefaultboolean("mbnames", "incremental", 0)
+
+    # Skip writing if we don't want incremental writing and we're not done.
+    if not incremental and not allcomplete:
+        return
+
+    # Skip writing if we want incremental writing and we're done.
+    if incremental and allcomplete:
+        return
+
     # See if we're ready to write it out.
     for account in accounts:
         if account not in boxes:


### PR DESCRIPTION
The basic problem is in the context of syncing multiple accounts where
one is fast and the others are slower (due to the number of folders).
When the fast account completes, the other accounts are partially
through the list and if the file is read during this time, the list can
be useless. However, in the general case, the file is probably left
around from a previous run of offlineimap and is more correct, so add an
option to leave it alone until all syncing is done.

Incremental is still the default since this running offlineimap using
its own timer setup is likely the most common setup. Turning it off
works best with one-shot mode triggered by cron or systemd timers.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>