### PR TITLE
fix paths in systemd README

### DIFF
--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -2,8 +2,8 @@ Systemd units
 =============
 
 These unit files are meant to be used in the user session. You may drop them
-into `${XDG_DATA_HOME}/systemd/user` followed by `systemctl --user
-daemon-reload` to have systemd aware of the unit files.
+into `/etc/systemd/user` or `${XDG_CONFIG_HOME}/systemd/user` followed by
+`systemctl --user daemon-reload` to have systemd aware of the unit files.
 
 These files are meant to be triggered either manually using `systemctl --user
 start offlineimap.service` or by enabling the timer unit using `systemctl


### PR DESCRIPTION
The right places to manually put systemd user units is:

* /etc/systemd/user if you want them to be available to all users,

* ${XDG_CONFIG_HOME}/systemd/user for a single user.

The upstream rationale is: user configuration goes to /etc/systemd or
$XDG_CONFIG_HOME/systemd, while package provided config goes to
/usr/lib/systemd or $XDG_DATA_HOME/systemd.

If offlineimap ever installs systemd units from the install scripts, it
should install them to /usr/lib/systemd/user.