### PR TITLE
Add decodefoldernames option to decode IMAP folder names using UTF-7.

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -764,6 +764,20 @@ remoteuser = username
 
 # This option stands in the [Repository RemoteExample] section.
 #
+# IMAP defines an encoding for non-ASCII ("international") characters. Enable
+# this option if you want to decode them to the nowadays ubiquitous UTF-8.
+#
+# Note that the IMAP 4rev1 specification (RFC 3501) allows both UTF-8 and
+# modified UTF-7 folder names.
+#
+# This option is disabled by default to retain compatibility with older versions
+# of offlineimap.
+#
+#decodefoldernames = no
+
+
+# This option stands in the [Repository RemoteExample] section.
+#
 # In between synchronisations, OfflineIMAP can monitor mailboxes for new
 # messages using the IDLE command. If you want to enable this, specify here the
 # folders you wish to monitor. IMAP protocol requires a separate connection for

--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -259,6 +259,13 @@ class IMAPFolder(BaseFolder):
         self.messagelist = {}
 
     # Interface from BaseFolder
+    def getvisiblename(self):
+        vname = super(IMAPFolder, self).getvisiblename()
+        if self.repository.getdecodefoldernames():
+            return imaputil.decode_mailbox_name(vname)
+        return vname
+
+    # Interface from BaseFolder
     def getmessagelist(self):
         return self.messagelist
 

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -261,6 +261,9 @@ class IMAPRepository(BaseRepository):
     def getreference(self):
         return self.getconf('reference', '')
 
+    def getdecodefoldernames(self):
+        return self.getconfboolean('decodefoldernames', 0)
+
     def getidlefolders(self):
         localeval = self.localeval
         return localeval.eval(self.getconf('idlefolders', '[]'))


### PR DESCRIPTION
This is a fix for #192, without having to convert the core to Unicode.

Note that the UI still shows the original name since BaseFolder.__str__ uses name rather than visiblename.

Signed-off-by: Tommie Gannert <tommie@gannert.se>