### PR TITLE
Fix a typo in the new mail hook example.

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -304,7 +304,7 @@ remoterepository = RemoteExample
 #
 # This feature is experimental.
 #
-#newmail_hook = lambda: os.sytem("cvlc --play-and-exit /path/to/sound/file.mp3" +
+#newmail_hook = lambda: os.system("cvlc --play-and-stop --play-and-exit /path/to/sound/file.mp3" +
 #				 " > /dev/null 2>&1")
 
 


### PR DESCRIPTION
Also add --play-and-stop since if vlc is being used with the loop option, at the same time that cvlc is executed, the sound will play endlessly.

Signed-off-by: Matthew Krafczyk <krafczyk.matthew@gmail.com>