### PR TITLE
fix status code to reflect success or failure to sync

### DIFF
--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -48,7 +48,8 @@ class OfflineImap:
         if options.diagnostics:
             self.__serverdiagnostics(options)
         else:
-            self.__sync(options)
+            retval = self.__sync(options)
+            return retval
 
     def __parse_cmd_options(self):
         parser = OptionParser(version=offlineimap.__bigversion__,
@@ -339,11 +340,13 @@ class OfflineImap:
                 offlineimap.mbnames.write(True)
 
             self.ui.terminate()
+            return 0
         except (SystemExit):
             raise
         except Exception as e:
             self.ui.error(e)
             self.ui.terminate()
+            return 1
 
     def __sync_singlethreaded(self, accs):
         """Executed if we do not want a separate syncmaster thread


### PR DESCRIPTION
Return value set to 1 if sync failed and error is thrown. Otherwise set to 0 if successful.