### PR TITLE
systemd: log to syslog rather than stderr

### DIFF
--- a/contrib/systemd/offlineimap.service
+++ b/contrib/systemd/offlineimap.service
@@ -3,7 +3,7 @@ Description=Offlineimap Service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/offlineimap -o
+ExecStart=/usr/bin/offlineimap -o -s -u quiet
 
 [Install]
 WantedBy=mail.target

--- a/contrib/systemd/offlineimap@.service
+++ b/contrib/systemd/offlineimap@.service
@@ -3,7 +3,7 @@ Description=Offlineimap Service for account %i
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/offlineimap -o -a %i
+ExecStart=/usr/bin/offlineimap -o -a %i -s -u quiet
 
 [Install]
 WantedBy=mail.target


### PR DESCRIPTION
This allows the journal to capture output with the appropriate level.

Signed-off-by: Ben Boeckel <mathstuf@gmail.com>