### PR TITLE
Fix syslog handler

### DIFF
--- a/contrib/systemd/offlineimap.service
+++ b/contrib/systemd/offlineimap.service
@@ -3,7 +3,7 @@ Description=Offlineimap Service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/offlineimap -o -s -u quiet
+ExecStart=/usr/bin/offlineimap -o -u syslog
 
 [Install]
 WantedBy=mail.target

--- a/contrib/systemd/offlineimap@.service
+++ b/contrib/systemd/offlineimap@.service
@@ -3,7 +3,7 @@ Description=Offlineimap Service for account %i
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/offlineimap -o -a %i -s -u quiet
+ExecStart=/usr/bin/offlineimap -o -a %i -u syslog
 
 [Install]
 WantedBy=mail.target

--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -149,7 +149,7 @@ option is ignored if maxage is set.
 +
 This overrides the default specified in the configuration file. The UI
 specified with -u will be forced to be used, even if checks determine that it
-is not usable. Possible interface choices are: quiet, basic, ttyui,
+is not usable. Possible interface choices are: quiet, basic, syslog, ttyui,
 blinkenlights, machineui.
 
 

--- a/docs/offlineimapui.txt
+++ b/docs/offlineimapui.txt
@@ -127,6 +127,17 @@ It will output nothing except errors and serious warnings.  Like Basic, this
 user interface is not capable of reading a password from the keyboard; account
 passwords must be specified using one of the configuration file options.
 
+
+Syslog
+------
+
+Syslog is designed for situations where OfflineIMAP is run as a daemon (e.g.,
+as a systemd --user service), but errors should be forwarded to the system log.
+Like Basic, this user interface is not capable of reading a password from the
+keyboard; account passwords must be specified using one of the configuration
+file options.
+
+
 MachineUI
 ---------
 

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -115,7 +115,7 @@ class OfflineImap:
 
         parser.add_option("-u", dest="interface",
                   help="specifies an alternative user interface"
-                  " (quiet, basic, ttyui, blinkenlights, machineui)")
+                  " (quiet, basic, syslog, ttyui, blinkenlights, machineui)")
 
         (options, args) = parser.parse_args()
         globals.set_options (options)

--- a/offlineimap/ui/Noninteractive.py
+++ b/offlineimap/ui/Noninteractive.py
@@ -17,6 +17,7 @@
 
 import logging
 from offlineimap.ui.UIBase import UIBase
+import offlineimap
 
 class Basic(UIBase):
     """'Basic' simply sets log level to INFO"""
@@ -27,3 +28,22 @@ class Quiet(UIBase):
     """'Quiet' simply sets log level to WARNING"""
     def __init__(self, config, loglevel = logging.WARNING):
         return super(Quiet, self).__init__(config, loglevel)
+
+class Syslog(UIBase):
+    """'Syslog' sets log level to INFO and outputs to syslog instead of stdout"""
+    def __init__(self, config, loglevel = logging.INFO):
+        return super(Syslog, self).__init__(config, loglevel)
+
+    def setup_consolehandler(self):
+        # create syslog handler
+        ch = logging.handlers.SysLogHandler('/dev/log')
+        # create formatter and add it to the handlers
+        self.formatter = logging.Formatter("%(message)s")
+        ch.setFormatter(self.formatter)
+        # add the handlers to the logger
+        self.logger.addHandler(ch)
+        self.logger.info(offlineimap.banner)
+        return ch
+
+    def setup_sysloghandler(self):
+        pass

--- a/offlineimap/ui/Noninteractive.py
+++ b/offlineimap/ui/Noninteractive.py
@@ -19,7 +19,7 @@ import logging
 from offlineimap.ui.UIBase import UIBase
 
 class Basic(UIBase):
-    """'Quiet' simply sets log level to INFO"""
+    """'Basic' simply sets log level to INFO"""
     def __init__(self, config, loglevel = logging.INFO):
         return super(Basic, self).__init__(config, loglevel)
 

--- a/offlineimap/ui/UIBase.py
+++ b/offlineimap/ui/UIBase.py
@@ -16,6 +16,7 @@
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 import logging
+import logging.handlers
 import re
 import time
 import sys
@@ -94,9 +95,8 @@ class UIBase(object):
     def setup_sysloghandler(self):
         """Backend specific syslog handler."""
 
-        # create console handler with a higher log level
-        ch = logging.SysLogHandler(sys.stdout)
-        #ch.setLevel(logging.DEBUG)
+        # create syslog handler
+        ch = logging.handlers.SysLogHandler('/dev/log')
         # create formatter and add it to the handlers
         self.formatter = logging.Formatter("%(message)s")
         ch.setFormatter(self.formatter)

--- a/offlineimap/ui/__init__.py
+++ b/offlineimap/ui/__init__.py
@@ -21,6 +21,7 @@ from offlineimap.ui import TTY, Noninteractive, Machine
 UI_LIST = {'ttyui': TTY.TTYUI,
            'basic': Noninteractive.Basic,
            'quiet': Noninteractive.Quiet,
+           'syslog': Noninteractive.Syslog,
            'machineui': Machine.MachineUI}
 
 #add Blinkenlights UI if it imports correctly (curses installed)


### PR DESCRIPTION
---
OK, so this seems to be a *much* better way to do syslog handling rather than tacking it onto whatever other UI is chosen. The problem I had hit before is that, by default, the UDP socket is used by Python for logging to syslog. Using `/dev/log` which is always available gives good journal output (with proper error detection and all).