### PR TITLE
fix: avoid writing password to log. (fixes #266)

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -206,7 +206,8 @@ class IMAPServer:
             authz = self.user_identity
         NULL = u'\x00'
         retval = NULL.join((authz, authc, passwd)).encode('utf-8')
-        self.ui.debug('imap', '__plainhandler: returning %s' % retval)
+        logsafe_retval = NULL.join((authz, authc, "(passwd hidden for log)")).encode('utf-8')
+        self.ui.debug('imap', '__plainhandler: returning %s' % logsafe_retval)
         return retval
 
 


### PR DESCRIPTION
Avoids writing password to log, even in debug mode as this is unsafe for plenty of reason (some of these are detailled in #266)