### PR TITLE
fix: dev: typo that screws emacs syntax highlighting. !minor

### DIFF
--- a/offlineimap/imaplib2.py
+++ b/offlineimap/imaplib2.py
@@ -869,7 +869,7 @@ class IMAP4(object):
 
 
     def idle(self, timeout=None, **kw):
-        """"(typ, [data]) = idle(timeout=None)
+        """(typ, [data]) = idle(timeout=None)
         Put server into IDLE mode until server notifies some change,
         or 'timeout' (secs) occurs (default: 29 minutes),
         or another IMAP4 command is scheduled."""


### PR DESCRIPTION
Signed-off-by: Valentin Lab <valentin.lab@kalysto.org>