### PR TITLE
Fix uploading binary attachments to IMAP.

### DIFF
--- a/offlineimap/imaplib2.py
+++ b/offlineimap/imaplib2.py
@@ -1383,7 +1383,10 @@ class IMAP4(object):
             self.literal = None
             if isinstance(literal, string_types):
                 literator = None
-                data = '%s {%s}' % (data, len(literal))
+                if 'BINARY' in self.capabilities:
+                    data = '%s ~{%s}' % (data, len(literal))
+                else:
+                    data = '%s {%s}' % (data, len(literal))
             else:
                 literator = literal
 


### PR DESCRIPTION
OfflineIMAP can try and upload binary data to the server if it thinks it
has to. It should better mark its literals as binary per RFC 3516 if the
server advertises it.

Can probably be backported in the other branches.