### PR TITLE
Fix broken retry loop (fixes #198)

### DIFF
--- a/TODO.rst
+++ b/TODO.rst
@@ -120,8 +120,4 @@ TODO list
   so don't matter much about that if you don't get the point or what could be
   done.
 
-
-* Support Python 3.
-
-
 * Support Unicode.

--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -536,6 +536,31 @@ localfolders = ~/Test
 #
 #filename_use_mail_timestamp = no
 
+# This option stands in the [Repository LocalExample] section.
+#
+# Map IMAP [user-defined] keywords to lowercase letters, similar to Dovecot's
+# format described in http://wiki2.dovecot.org/MailboxFormat/Maildir . This
+# option makes sense for the Maildir type, only.
+#
+# Configuration example:
+#      customflag_x = some_keyword
+#
+# With the configuration example above enabled, all IMAP messages that have
+# 'some_keyword' in their FLAGS field will have an 'x' in the flags part of the
+# maildir filename:
+#      1234567890.M20046P2137.mailserver,S=4542,W=4642:2,Sx
+#
+# Valid fields are customflag_[a-z], valid values are whatever the IMAP server
+# allows.
+#
+# Comparison in offlineimap is case-sensitive.
+#
+# This option is EXPERIMENTAL.
+#
+#customflag_a = some_keyword
+#customflag_b = $OtherKeyword
+#customflag_c = NonJunk
+#customflag_d = ToDo
 
 [Repository GmailLocalExample]
 

--- a/offlineimap/folder/Gmail.py
+++ b/offlineimap/folder/Gmail.py
@@ -72,11 +72,7 @@ class GmailFolder(IMAPFolder):
                   (probably severity MESSAGE) if e.g. no message with
                   this UID could be found.
         """
-        imapobj = self.imapserver.acquireconnection()
-        try:
-            data = self._fetch_from_imap(imapobj, str(uid), 2)
-        finally:
-            self.imapserver.releaseconnection(imapobj)
+        data = self._fetch_from_imap(str(uid), 2)
 
         # data looks now e.g.
         #[('320 (X-GM-LABELS (...) UID 17061 BODY[] {2565}','msgbody....')]

--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -251,8 +251,10 @@ class IMAPFolder(BaseFolder):
                 uid = long(options['UID'])
                 self.messagelist[uid] = self.msglist_item_initializer(uid)
                 flags = imaputil.flagsimap2maildir(options['FLAGS'])
+                keywords = imaputil.flagsimap2keywords(options['FLAGS'])
                 rtime = imaplibutil.Internaldate2epoch(messagestr)
-                self.messagelist[uid] = {'uid': uid, 'flags': flags, 'time': rtime}
+                self.messagelist[uid] = {'uid': uid, 'flags': flags, 'time': rtime,
+                    'keywords': keywords}
         self.ui.messagelistloaded(self.repository, self, self.getmessagecount())
 
     def dropmessagelistcache(self):
@@ -308,6 +310,10 @@ class IMAPFolder(BaseFolder):
     # Interface from BaseFolder
     def getmessageflags(self, uid):
         return self.messagelist[uid]['flags']
+
+    # Interface from BaseFolder
+    def getmessagekeywords(self, uid):
+        return self.messagelist[uid]['keywords']
 
     def __generate_randomheader(self, content):
         """Returns a unique X-OfflineIMAP header

--- a/offlineimap/folder/IMAP.py
+++ b/offlineimap/folder/IMAP.py
@@ -282,11 +282,7 @@ class IMAPFolder(BaseFolder):
                   this UID could be found.
         """
 
-        imapobj = self.imapserver.acquireconnection()
-        try:
-            data = self._fetch_from_imap(imapobj, str(uid), 2)
-        finally:
-            self.imapserver.releaseconnection(imapobj)
+        data = self._fetch_from_imap(str(uid), 2)
 
         # data looks now e.g. [('320 (UID 17061 BODY[]
         # {2565}','msgbody....')]  we only asked for one message,
@@ -680,7 +676,7 @@ class IMAPFolder(BaseFolder):
         return uid
 
 
-    def _fetch_from_imap(self, imapobj, uids, retry_num=1):
+    def _fetch_from_imap(self, uids, retry_num=1):
         """Fetches data from IMAP server.
 
         Arguments:
@@ -690,22 +686,33 @@ class IMAPFolder(BaseFolder):
 
         Returns: data obtained by this query."""
 
-        query = "(%s)"% (" ".join(self.imap_query))
-        fails_left = retry_num # retry on dropped connection
-        while fails_left:
-            try:
-                imapobj.select(self.getfullname(), readonly = True)
-                res_type, data = imapobj.uid('fetch', uids, query)
-                fails_left = 0
-            except imapobj.abort as e:
-                # Release dropped connection, and get a new one
-                self.imapserver.releaseconnection(imapobj, True)
-                imapobj = self.imapserver.acquireconnection()
-                self.ui.error(e, exc_info()[2])
-                fails_left -= 1
-                # self.ui.error() will show the original traceback
-                if not fails_left:
-                    raise e
+        imapobj = self.imapserver.acquireconnection()
+        try:
+            query = "(%s)"% (" ".join(self.imap_query))
+            fails_left = retry_num  ## retry on dropped connection
+            while fails_left:
+                try:
+                    imapobj.select(self.getfullname(), readonly = True)
+                    res_type, data = imapobj.uid('fetch', uids, query)
+                    break
+                except imapobj.abort as e:
+                    fails_left -= 1
+                    # self.ui.error() will show the original traceback
+                    if fails_left <= 0:
+                        message = ("%s, while fetching msg %r in folder %r. Max retry reached (%d)"
+                                   % (e, uids, self.name, retry_num, ))
+                        severity = OfflineImapError.ERROR.MESSAGE
+                        raise OfflineImapError(message, OfflineImapError.ERROR.MESSAGE)
+                    # Release dropped connection, and get a new one
+                    self.imapserver.releaseconnection(imapobj, True)
+                    imapobj = self.imapserver.acquireconnection()
+                    self.ui.error("%s. While fetching msg %r in folder %r. Retrying (%d/%d)"
+                                  % (e, uids, self.name, retry_num - fails_left,
+                                     retry_num, ))
+        finally:
+            ## the imapobj here might be different than the one 
+            self.imapserver.releaseconnection(imapobj)
+
         if data == [None] or res_type != 'OK':
             #IMAP server says bad request or UID does not exist
             severity = OfflineImapError.ERROR.MESSAGE

--- a/offlineimap/folder/Maildir.py
+++ b/offlineimap/folder/Maildir.py
@@ -135,9 +135,7 @@ class MaildirFolder(BaseFolder):
                 uid = long(uidmatch.group(1))
         flagmatch = self.re_flagmatch.search(filename)
         if flagmatch:
-            # Filter out all lowercase (custom maildir) flags. We don't
-            # handle them yet.
-            flags = set((c for c in flagmatch.group(1) if not c.islower()))
+            flags = set((c for c in flagmatch.group(1)))
         return prefix, uid, fmd5, flags
 
     def _scanfolder(self, min_date=None, min_uid=None):
@@ -149,7 +147,7 @@ class MaildirFolder(BaseFolder):
         with similar UID's (e.g. the UID was reassigned much later).
 
         Maildir flags are: R (replied) S (seen) T (trashed) D (draft) F
-        (flagged).
+        (flagged), plus lower-case letters for custom flags.
         :returns: dict that can be used as self.messagelist.
         """
 
@@ -414,8 +412,7 @@ class MaildirFolder(BaseFolder):
 
         if flags != self.messagelist[uid]['flags']:
             # Flags have actually changed, construct new filename Strip
-            # off existing infostring (possibly discarding small letter
-            # flags that dovecot uses TODO)
+            # off existing infostring
             infomatch = self.re_flagmatch.search(filename)
             if infomatch:
                 filename = filename[:-len(infomatch.group())] #strip off

--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -195,6 +195,14 @@ def flagsimap2maildir(flagstring):
             retval.add(maildirflag)
     return retval
 
+def flagsimap2keywords(flagstring):
+    """Convert string '(\\Draft \\Deleted somekeyword otherkeyword)' into a
+    keyword set (somekeyword otherkeyword)."""
+
+    imapflagset = set(flagstring[1:-1].split())
+    serverflagset = set([flag for (flag, c) in flagmap])
+    return imapflagset - serverflagset
+
 def flagsmaildir2imap(maildirflaglist):
     """Convert set of flags ([DR]) into a string '(\\Deleted \\Draft)'."""
 

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -299,7 +299,7 @@ class OfflineImap:
                 stack_display.append('  => Stopped to handle current signal. ')
             stack_displays.append(stack_display)
         stacks = unique_count(stack_displays)
-        print "** Thread List:\n"
+        print("** Thread List:\n")
         for stack, times in stacks:
             if times == 1:
                 msg = "%s Thread is at:\n%s\n"

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -299,7 +299,7 @@ class OfflineImap:
                 stack_display.append('  => Stopped to handle current signal. ')
             stack_displays.append(stack_display)
         stacks = unique_count(stack_displays)
-        print("** Thread List:\n")
+        self.ui.debug('thread', "** Thread List:\n")
         for stack, times in stacks:
             if times == 1:
                 msg = "%s Thread is at:\n%s\n"

--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -31,6 +31,9 @@ from offlineimap.ui import UI_LIST, setglobalui, getglobalui
 from offlineimap.CustomConfig import CustomConfigParser
 from offlineimap.utils import stacktrace
 
+import traceback
+import collections
+
 
 class OfflineImap:
     """The main class that encapsulates the high level use of OfflineImap.
@@ -272,6 +275,42 @@ class OfflineImap:
         self.config = config
         return (options, args)
 
+    def __dumpstacks(self, context=1, sighandler_deep=2):
+        """ Signal handler: dump a stack trace for each existing thread."""
+
+        currentThreadId = threading.currentThread().ident
+
+        def unique_count(l):
+            d = collections.defaultdict(lambda: 0)
+            for v in l:
+                d[tuple(v)] += 1
+            return list((k, v) for k, v in d.iteritems())
+
+        stack_displays = []
+        for threadId, stack in sys._current_frames().items():
+            stack_display = []
+            for filename, lineno, name, line in traceback.extract_stack(stack):
+                stack_display.append('  File: "%s", line %d, in %s'
+                                     % (filename, lineno, name))
+                if line:
+                    stack_display.append("    %s" % (line.strip()))
+            if currentThreadId == threadId:
+                stack_display = stack_display[:- (sighandler_deep * 2)]
+                stack_display.append('  => Stopped to handle current signal. ')
+            stack_displays.append(stack_display)
+        stacks = unique_count(stack_displays)
+        print "** Thread List:\n"
+        for stack, times in stacks:
+            if times == 1:
+                msg = "%s Thread is at:\n%s\n"
+            else:
+                msg = "%s Threads are at:\n%s\n"
+            self.ui.debug('thread', msg % (times, '\n'.join(stack[- (context * 2):])))
+
+        self.ui.debug('thread', "Dumped a total of %d Threads." %
+                      len(sys._current_frames().keys()))
+
+
     def __sync(self, options):
         """Invoke the correct single/multithread syncing
 
@@ -321,6 +360,8 @@ class OfflineImap:
                     getglobalui().warn("Terminating NOW (this may "\
                                        "take a few seconds)...")
                     accounts.Account.set_abort_event(self.config, 3)
+                    if 'thread' in self.ui.debuglist:
+                        self.__dumpstacks(5)
                 elif sig == signal.SIGQUIT:
                     stacktrace.dump(sys.stderr)
                     os.abort()

--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -133,6 +133,9 @@ class BaseRepository(CustomConfig.ConfigHelperMixin, object):
     def getsep(self):
         raise NotImplementedError
 
+    def getkeywordmap(self):
+        raise NotImplementedError
+
     def should_sync_folder(self, fname):
         """Should this folder be synced?"""
 

--- a/offlineimap/repository/Maildir.py
+++ b/offlineimap/repository/Maildir.py
@@ -39,6 +39,14 @@ class MaildirRepository(BaseRepository):
         if not os.path.isdir(self.root):
             os.mkdir(self.root, 0o700)
 
+        # Create the keyword->char mapping
+        self.keyword2char = dict()
+        for c in 'abcdefghijklmnopqrstuvwxyz':
+            confkey = 'customflag_' + c
+            keyword = self.getconf(confkey, None)
+            if keyword is not None:
+                self.keyword2char[keyword] = c
+
     def _append_folder_atimes(self, foldername):
         """Store the atimes of a folder's new|cur in self.folder_atimes"""
 
@@ -71,6 +79,9 @@ class MaildirRepository(BaseRepository):
 
     def getsep(self):
         return self.getconf('sep', '.').strip()
+
+    def getkeywordmap(self):
+        return self.keyword2char if len(self.keyword2char) > 0 else None
 
     def makefolder(self, foldername):
         """Create new Maildir folder if necessary


### PR DESCRIPTION
The issue was in ``getmessage()`` code. For some reason it asks for a connection, runs ``_fetch_from_imap`` and with a ``try/finally`` will ask to release the connection. But ``_fetch_from_imap`` will close and require a new connection in case it fails for whatever reason to implement a retry mecanism. So when coming back to ``getmessage()`` and it's ``finally`` clause, the connection was already closed and removed from the list of available connections.

Independently to this bug, Dovecot won't be very kind upon error on his side, and as a result at least on my setup, it'll close abruptly the connection instead of giving a nice IMAP error. As a consequence, the bogus retry loop is activated quite often. 