### PR TITLE
Identify and fix messages with FMD5 inconsistencies

### DIFF
--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -163,6 +163,20 @@ blinkenlights, machineui.
 This option is only applicable in non-verbose mode.
 
 
+--migrate-fmd5-using-nametrans::
+  Migrate FMD5 hashes from versions prior to 6.3.5.
++
+The way that FMD5 hashes are calculated was changed in version 6.3.5 (now using
+the nametrans folder name) introducing a regression which may lead to
+re-uploading all messages. Try and fix the above regression by calculating the
+correct FMD5 values and renaming the corresponding messages.
+
+CAUTION: Since the FMD5 part of the filename changes, this may lead to UID
+conflicts. Ensure to dispose a proper backup of both the cache and the Maildir
+before running this fix as well as verify the results using the `--dry-run'
+flag first.
+
+
 Synchronization Performance
 ---------------------------
 


### PR DESCRIPTION
- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested.

Introduce the '--migrate-fmd5-using-nametrans' option which migrates the
FMD5 hashes from versions prior to 6.3.5.

It seems that commit 'Apply nametrans to all Foldertypes' (6b2ec956cf)
introduced a regression because it changed the FMD5 part of the filename
calculated by OfflineIMAP. Thus, OfflineIMAP believes that the messages
has been removed and adds them back.

For more information, see:
http://www.offlineimap.org/configuration/2016/02/12/debian-upgrade-from-jessie-to-stretch.html

Bug-Debian: https://bugs.debian.org/812108
Reported-by: François <francois@avalenn.eu>
Signed-off-by: Ilias Tsitsimpis <i.tsitsimpis@gmail.com>