### PR TITLE
blinkenlights/ncurses 6: fix resize loop bug (#290)

### DIFF
--- a/offlineimap/ui/Curses.py
+++ b/offlineimap/ui/Curses.py
@@ -570,6 +570,7 @@ class Blinkenlights(UIBase, CursesUtil):
         self.height, self.width = self.stdscr.getmaxyx()
         self.logheight = self.height - len(self.accframes) - 1
         if resize:
+            self.inputhandler.input_acquire()
             curses.resizeterm(self.height, self.width)
             self.bannerwin.resize(1, self.width)
             self.logwin.resize(self.logheight, self.width)
@@ -592,6 +593,15 @@ class Blinkenlights(UIBase, CursesUtil):
             index += 1
             pos -= 1
         curses.doupdate()
+
+        if resize:
+            # eat any KEY_RESIZE events caused by this resize handler
+            # (otherwise we get an infinite loop of resizing with ncurses 6)
+            key = self.stdscr.getch()
+            while key == curses.KEY_RESIZE:
+                key = self.stdscr.getch()
+            curses.ungetch(key)
+            self.inputhandler.input_release()
 
     def draw_bannerwin(self):
         """Draw the top-line banner line."""


### PR DESCRIPTION
### Peer reviews

Trick to [fetch the pull request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #290

### Additional information

It seems setupwindows() is causing ungetch(KEY_RESIZE), which results in
an infinite loop of setupwindows().

This commit disables the inputhandler while resizing, eats any
KEY_RESIZE events before re-enabling the inputhandler.

This change makes the blinkenlights UI display without flickering, and
the keybindings work with ncurses 6.