### PR TITLE
[FIX] bug creating folder name / on remote imap server

### DIFF
--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -207,6 +207,8 @@ class BaseRepository(CustomConfig.ConfigHelperMixin, object):
                                                    status_repo.getsep()))
         # Find new folders on dst_repo.
         for dst_name_t, dst_folder in dst_hash.iteritems():
+            if dst_name_t == '':
+                continue
             if not src_repo.get_create_folders():
                 # Don't create missing folder on readonly repo.
                 break


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> [FIX] bug creating folder name / on remote imap server

- [] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [] Code changes follow the style of the files they change.
- [] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


