### PR TITLE
Use system encoding to decode passwords and usernames (fix #59)

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -26,7 +26,7 @@ import urllib
 import socket
 import time
 import errno
-from sys import exc_info
+from sys import exc_info, stdout
 from socket import gaierror
 from ssl import SSLError, cert_time_to_seconds
 
@@ -207,9 +207,9 @@ class IMAPServer:
         """Implements SASL PLAIN authentication, RFC 4616,
           http://tools.ietf.org/html/rfc4616"""
 
-        authc = self.username
-        passwd = self.__getpassword()
-        authz = ''
+        authc = unicode(self.username, stdout.encoding)
+        passwd = unicode(self.__getpassword(), stdout.encoding)
+        authz = u''
         if self.user_identity != None:
             authz = self.user_identity
         NULL = u'\x00'


### PR DESCRIPTION
### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (tested on both ascii and unicode passwords).

### References

- Issue #59

### Additional information

u'\x00'.join() will implicitly decode all bytestrings that are provided,
using the default codec. The default codec being "ascii", this change
uses stdout encoding to try to decode the password and username. This
cannot provide worse compatibility than the existing behavior (which
breaks on any non-ascii character), and can be tweaked using the
environment in the edge cases.