### PR TITLE
Fixed https://github.com/OfflineIMAP/offlineimap/issues/336.

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -778,6 +778,9 @@ class BaseFolder(object):
         :param register: whether we should register a new thread."
         :returns: Nothing on success, or raises an Exception."""
 
+        if uid == 0: # assert that the UID is non-zero (non-complaint servers) #336.
+            raise OfflineImapError("Trying to copy msg with uid 0", OfflineImapError.ERROR.MESSAGE)
+
         # Sometimes, it could be the case that if a sync takes awhile,
         # a message might be deleted from the maildir before it can be
         # synced to the status cache.  This is only a problem with
@@ -868,6 +871,8 @@ class BaseFolder(object):
                 rtime = self.getmessagetime(uid)
                 statusfolder.savemessage(uid, None, flags, rtime)
                 continue
+            elif uid == 0:
+                continue # skip to the next message (ignore) #336
 
             self.ui.copyingmessage(uid, num+1, num_to_copy, self, dstfolder)
             # exceptions are caught in copymessageto()


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [] Code changes follow the style of the files they change.
- [] Code is tested (provide details).

### References

- Issue #336.

### Additional information



