### PR TITLE
Fix bug in GmailMaildir cause by still adding a tuple to syncmessages…

### DIFF
--- a/offlineimap/folder/GmailMaildir.py
+++ b/offlineimap/folder/GmailMaildir.py
@@ -40,8 +40,7 @@ class GmailMaildirFolder(MaildirFolder):
 
         # If synclabels is enabled, add a 4th pass to sync labels.
         if self.synclabels:
-            self.syncmessagesto_passes.append(('syncing labels',
-                                               self.syncmessagesto_labels))
+            self.syncmessagesto_passes.append(self.syncmessagesto_labels)
 
     def quickchanged(self, statusfolder):
         """Returns True if the Maildir has changed.


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details). Locally against GMAIL and it fixes the error.

### References

- no issues raised

### Additional information



…to_passes

Signed-off-by: Philipp Meier <github@philipp.meier.name>