### PR TITLE
ConfigHelperMixin should inherit from object

### DIFF
--- a/offlineimap/CustomConfig.py
+++ b/offlineimap/CustomConfig.py
@@ -165,7 +165,7 @@ def CustomConfigDefault():
 
 
 
-class ConfigHelperMixin:
+class ConfigHelperMixin(object):
     """Allow comfortable retrieving of config values pertaining
     to a section.
 


### PR DESCRIPTION
In 88e8a489 the object parent for BaseRepository is removed. This breaks
any use of super() for any Repository class. It breaks gmail.

Was there any reason for ConfigHelperMixin not inheriting from object
and using multiple inheritance on BaseRepository?

Signed-off-by: Abdo Roig-Maranges <abdo.roig@gmail.com>