### PR TITLE
Fix failure-causing typo in format string in machineui

### DIFF
--- a/offlineimap/ui/Machine.py
+++ b/offlineimap/ui/Machine.py
@@ -103,7 +103,7 @@ class MachineUI(UIBase):
                  folder.get_saveduidvalidity(), folder.get_uidvalidity()))
 
     def connecting(s, reposname, hostname, port):
-        s._printData(s.logger.info, 'connecting', "%s\n%s\nMs"% (hostname,
+        s._printData(s.logger.info, 'connecting', "%s\n%s\n%s"% (hostname,
             str(port), reposname))
 
     def syncfolders(s, srcrepos, destrepos):


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information



This was causing the error message "not all arguments converted during
string formatting." Specifically:

```
% offlineimap -u machineui
OfflineIMAP 7.0.4
  Licensed under the GNU GPL v2 or any later version (with an OpenSSL exception)
msg:protocol:MainThread:7.2.0
msg:initbanner:MainThread:OfflineIMAP+7.0.4%0A++Licensed+under+the+GNU+GPL+v2+or+any+later+version+%28with+an+OpenSSL+exception%29
msg:registerthread:Account+sync+MYHOST:MYHOST
msg:acct:Account+sync+MYHOST:MYHOST
error::Account+sync+MYHOST:ERROR%3A+While+attempting+to+sync+account+%27MYHOST%27%0A++not+all+arguments+converted+during+string+formatting
msg:acctdone:Account+sync+MYHOST:MYHOST
msg:threadExited:MainThread:Account+sync+MYHOST
msg:unregisterthread:MainThread:Account+sync+MYHOST
msg:terminate:MainThread:0%0A%0A
```

Signed-off-by: Christopher League <league@contrapunctus.net>