### PR TITLE
Add gentoo cert path for OS-DEFAULT

### DIFF
--- a/offlineimap/utils/distro.py
+++ b/offlineimap/utils/distro.py
@@ -7,7 +7,7 @@ import os
 
 
 # Each dictionary value is either string or some iterable.
-# 
+#
 # For the former we will just return the value, for an iterable
 # we will walk through the values and will return the first
 # one that corresponds to the existing file.
@@ -21,6 +21,7 @@ __DEF_OS_LOCATIONS = {
     ],
     'linux-ubuntu': '/etc/ssl/certs/ca-certificates.crt',
     'linux-debian': '/etc/ssl/certs/ca-certificates.crt',
+    'linux-gentoo': '/etc/ssl/certs/ca-certificates.crt',
     'linux-fedora': '/etc/pki/tls/certs/ca-bundle.crt',
     'linux-redhat': '/etc/pki/tls/certs/ca-bundle.crt',
     'linux-suse': '/etc/ssl/ca-bundle.pem',
@@ -43,13 +44,13 @@ def get_os_name():
     if OS.startswith('linux'):
         DISTRO = platform.linux_distribution()[0]
         if DISTRO:
-          OS = OS + "-%s" % DISTRO.lower()
+          OS = OS + "-%s" % DISTRO.split()[0].lower()
 
     return OS
 
 def get_os_sslcertfile_searchpath():
     """Returns search path for CA bundle for the current OS.
-    
+
     We will return an iterable even if configuration has just
     a single value: it is easier for our callers to be sure
     that they can iterate over result.


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information

Not unit tested, but tested on my machine. Also, see below for output of `platform.linux_distribution()` on Gentoo. It is three words, which is why the `.split()[0]` is necessary.

```python
import platform
platform.linux_distribution()
('Gentoo Base System', '2.2', '')
```


Signed-off-by: Espen Henriksen <dev@henriksen.is>