### PR TITLE
Fix implicit call to unicode() from UI functions

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -98,6 +98,11 @@ class BaseFolder(object):
         # FIMXE: remove calls of this. We have getname().
         return self.name
 
+    def __unicode__(self):
+        # NOTE(sheeprine): Implicit call to this by UIBase deletingflags() which
+        # fails if the str is utf-8
+        return self.name.decode('utf-8')
+
     @property
     def accountname(self):
         """Account name as string"""


### PR DESCRIPTION
### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information
This code has been tested on my setups and remove any occurrences of the Unicode Exception on flag deletion.

BaseFolder now exposes an __unicode__ method so that function needing
unicode transcoding don't crash due to ascii encoding errors.