### PR TITLE
Import ui before threadutil to resolve circular dependency

### DIFF
--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -27,8 +27,11 @@ from optparse import OptionParser
 
 import offlineimap
 import offlineimap.virtual_imaplib2 as imaplib
-from offlineimap import globals, threadutil, accounts, folder, mbnames
+
+# Ensure that `ui` gets loaded before `threadutil` in order to
+# break the circular dependency between `threadutil` and `Curses`.
 from offlineimap.ui import UI_LIST, setglobalui, getglobalui
+from offlineimap import globals, threadutil, accounts, folder, mbnames
 from offlineimap.CustomConfig import CustomConfigParser
 from offlineimap.utils import stacktrace
 from offlineimap.repository import Repository


### PR DESCRIPTION
### Peer reviews

Trick to [fetch the pull request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested.

### Additional information



The `threadutil` module depends on the `ui` module, which cycle depends
on `threadutil` through the `Curses` module.

The `ui` module had been loaded before the `threadutil` module, breaking
the above circular dependency, but this was changed in a recent code
refactoring, preventing the `Curses` module from being loaded with the
following exception:

```python
  File "./offlineimap.py", line 23, in <module>
    from offlineimap import OfflineImap
  File "offlineimap/offlineimap/__init__.py", line 20, in <module>
    from offlineimap.init import OfflineImap
  File "offlineimap/offlineimap/init.py", line 30, in <module>
    from offlineimap import globals, threadutil, accounts, folder, mbnames
  File "offlineimap/offlineimap/threadutil.py", line 25, in <module>
    from offlineimap.ui import getglobalui
  File "offlineimap/offlineimap/ui/__init__.py", line 28, in <module>
    from offlineimap.ui import Curses
  File "offlineimap/offlineimap/ui/Curses.py", line 27, in <module>
    from offlineimap.threadutil import ExitNotifyThread
ImportError: cannot import name ExitNotifyThread
```

Fix the above error by ensuring that the `ui` module gets loaded before
the `threadutil` module. Please note that the above fix is temporary,
and we should refactor the modules to not have circular dependencies.

Bug-Debian: https://bugs.debian.org/839862
Reported-by: Neil McGovern <neilm@debian.org>
Signed-off-by: Ilias Tsitsimpis <i.tsitsimpis@gmail.com>