### PR TITLE
Fix flickering in Blinkenlights UI

### DIFF
--- a/offlineimap/ui/Curses.py
+++ b/offlineimap/ui/Curses.py
@@ -149,6 +149,7 @@ class CursesAccountFrame:
         self.window = curses_win
         self.acc_num = acc_num
         self.drawleadstr()
+        self.ui.exec_locked(self.window.noutrefresh)
         # Update the child ThreadFrames
         for child in self.children:
             child.update(curses_win, self.location, 0)
@@ -510,6 +511,7 @@ class Blinkenlights(UIBase, CursesUtil):
         # received special KEY_RESIZE, resize terminal
         if key == curses.KEY_RESIZE:
             self.resizeterm()
+            return
 
         if key < 1 or key > 255:
             return
@@ -574,9 +576,12 @@ class Blinkenlights(UIBase, CursesUtil):
         self.height, self.width = self.stdscr.getmaxyx()
         self.logheight = self.height - len(self.accframes) - 1
         if resize:
-            curses.resizeterm(self.height, self.width)
+            if curses.is_term_resized(self.height, self.width):
+                curses.resizeterm(self.height, self.width)
             self.bannerwin.resize(1, self.width)
             self.logwin.resize(self.logheight, self.width)
+            self.stdscr.clear()
+            self.stdscr.noutrefresh()
         else:
             self.bannerwin = curses.newwin(1, self.width, 0, 0)
             self.logwin = curses.newwin(self.logheight, self.width, 1, 0)
@@ -621,8 +626,9 @@ class Blinkenlights(UIBase, CursesUtil):
         else:
             color = curses.A_NORMAL
         self.logwin.move(0, 0)
-        self.logwin.erase()
+        self.logwin.clear()
         self.logwin.bkgd(' ', color)
+        self.logwin.noutrefresh()
 
     def getaccountframe(self, acc_name):
         """Return an AccountFrame() corresponding to acc_name.


### PR DESCRIPTION
### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested. It works for me and @chneukirchen. Since there were no more replies, I am closing both #160 and #290.

### References

- Issue #160
- Issue #290

### Additional information

Do not call resizeterm(), unless is_term_resized() returns True. This
breaks the busy-loop where resizeterm() pushes a KEY_RESIZE onto the
FIFO causing the screen to be redrawn indefinitely (Issue #290).

Also, clear and refresh the main window after it has been resized. This
hopefully fixes the problem where Blinkenlights UI becomes unreadable
after terminal resize (Issue #160).

Closes #160: blinkenlights display is broken
Closes #290: ncurses flicker with blinkenlights UI
Bug-Debian: https://bugs.debian.org/671087
Bug-Debian: https://bugs.debian.org/809676
Signed-off-by: Ilias Tsitsimpis <i.tsitsimpis@gmail.com>