### PR TITLE
Fix utf7 decode error not caught

### DIFF
--- a/offlineimap/imaputil.py
+++ b/offlineimap/imaputil.py
@@ -368,5 +368,5 @@ def decode_mailbox_name(name):
 
     try:
         return ret.decode('utf-7').encode('utf-8')
-    except UnicodeEncodeError:
+    except (UnicodeDecodeError, UnicodeEncodeError):
         return name


### PR DESCRIPTION
Hi,

UTF7 can sometime fail causing an UnicodeDecodeError (in case of malformated utf7 string).
This patch catch the exception so we just send raw name.