### PR TITLE
Add OpenSUSE to list of supported distros

### DIFF
--- a/offlineimap/utils/distro.py
+++ b/offlineimap/utils/distro.py
@@ -25,6 +25,7 @@ __DEF_OS_LOCATIONS = {
     'linux-fedora': '/etc/pki/tls/certs/ca-bundle.crt',
     'linux-redhat': '/etc/pki/tls/certs/ca-bundle.crt',
     'linux-suse': '/etc/ssl/ca-bundle.pem',
+    'linux-opensuse': '/etc/ssl/ca-bundle.pem',
 }
 
 


### PR DESCRIPTION
### This PR

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (provide details).

### Additional information



get_os_name returns linux-opensuse on OpenSUSE, so add a line for linux-opensuse to __DEF_OS_LOCATIONS.

Signed-off-by: Michael Hohmuth <hohmuth@sax.de>