### PR TITLE
Fix nametrans checks

### DIFF
--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -271,8 +271,8 @@ class BaseRepository(CustomConfig.ConfigHelperMixin):
                     self.ui.error(e, exc_info()[2], "Creating folder %s on "
                                   "repository %s"% (remote_name, remote_repo))
                     raise
-                status_repo.makefolder(remote_name.replace(
-                    remote_repo.getsep(), status_repo.getsep()))
+                status_repo.makefolder(local_trans[remote_name].replace(
+                    local_repo.getsep(), status_repo.getsep()))
 
         # Find and create new folders from remote to local.
         for remote_name, remote_folder in remote_hash.items():

--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -282,17 +282,15 @@ class BaseRepository(CustomConfig.ConfigHelperMixin):
 
             if remote_folder.sync_this and not remote_name in local_hash.keys():
                 try:
-                    local_name = remote_folder.getvisiblename().replace(
-                        remote_repo.getsep(), local_repo.getsep())
-                    local_repo.makefolder(local_name)
+                    local_repo.makefolder(local_trans[remote_name])
                     # Need to refresh list.
                     local_repo.forgetfolders()
                 except OfflineImapError as e:
                     self.ui.error(e, exc_info()[2],
                          "Creating folder %s on repository %s"%
-                         (local_name, local_repo))
+                         (local_trans[remote_name], local_repo))
                     raise
-                status_repo.makefolder(local_name.replace(
+                status_repo.makefolder(local_trans[remote_name].replace(
                     local_repo.getsep(), status_repo.getsep()))
 
         # Find deleted folders.

--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -198,7 +198,7 @@ class BaseRepository(CustomConfig.ConfigHelperMixin):
         # the end, we are guaranteed that going back & forth, either local ->
         # remote -> local, or remote -> local -> remote, does not change the
         # folder name.
-        def _add_folder_translation(lname, rname):
+        def add_folder_translation(lname, rname):
             if lname in remote_trans and rname != remote_trans[lname]:
                 raise OfflineImapError(
                     "FOLDER NAMETRANS INCONSISTENCY! "
@@ -231,13 +231,13 @@ class BaseRepository(CustomConfig.ConfigHelperMixin):
             name = folder.getname()
             trans_name = folder.getvisiblename().replace(local_repo.getsep(),
                                                          remote_repo.getsep())
-            _add_folder_translation(name, trans_name)
+            add_folder_translation(name, trans_name)
 
         for folder in remote_repo.getfolders():
             name = folder.getname()
             trans_name = folder.getvisiblename().replace(remote_repo.getsep(),
                                                          local_repo.getsep())
-            _add_folder_translation(trans_name, name)
+            add_folder_translation(trans_name, name)
 
         # Create hashes with the names. Both remote_hash and local_hash are
         # keyed by folder names as in the remote repository, obtained via


### PR DESCRIPTION
This is an attempt at fixing #408. Please, do not merge yet, since it still causes problems on my setup.

If we do not resolve this quickly I'd suggest temporarily reverting 481efa95f68, since it is quite pernicious on common one-sided nametrans rules. It essentially clears the status folder each time.

Standing issues:

1. @nicolas33 Could you please check 5eae16d? I'm not sure why no-one noticed that earlier. Maybe I'm getting something wrong. It looks like the `Account` class expects local folder name [here](https://github.com/OfflineIMAP/offlineimap/blob/master/offlineimap/accounts.py#L534). 

2. Now the nametrans back&forth check is ok. However, when I add the reverse nametrans into my config it starts copying about 8k of messages from local to remote, which I'm positive exist on the remote. It looks like a different issue, which I will look at next.

3. This enforces the nametrans rules to be inverse one of the other, ignoring filters. This is not what is documented, and may be too restrictive. Enforcing it only for folders that the remote wants to sync can be done, but is slightly annoying to do.

4. We probably need some documentation changes after this, since now nametrans is forced to have an inverse transformation configured.