### PR TITLE
Fix name of the status folder

### DIFF
--- a/offlineimap/repository/Base.py
+++ b/offlineimap/repository/Base.py
@@ -242,6 +242,7 @@ class BaseRepository(CustomConfig.ConfigHelperMixin):
                         OfflineImapError.ERROR.REPO)
 
                 # End sanity check, actually create the folder.
+                local_name = local_folder.getname()
                 try:
                     remote_repo.makefolder(remote_name)
                     # Need to refresh list.
@@ -250,8 +251,8 @@ class BaseRepository(CustomConfig.ConfigHelperMixin):
                     self.ui.error(e, exc_info()[2], "Creating folder %s on "
                                   "repository %s"% (remote_name, remote_repo))
                     raise
-                status_repo.makefolder(remote_name.replace(
-                    remote_repo.getsep(), status_repo.getsep()))
+                status_repo.makefolder(local_name.replace(
+                    local_repo.getsep(), status_repo.getsep()))
 
         # Find and create new folders from remote to local.
         for remote_name, remote_folder in remote_hash.items():


### PR DESCRIPTION
When creating a folder on the remote, the status folder was created using the remote folder name, but then Account assumed the statusfolder name matched the local folder. Correct this.