### PR TITLE
Enable environment variable expansion on Repository.localfolders

### DIFF
--- a/offlineimap/repository/Maildir.py
+++ b/offlineimap/repository/Maildir.py
@@ -71,7 +71,7 @@ class MaildirRepository(BaseRepository):
             os.utime(cur_dir, (cur_atime, os.path.getmtime(cur_dir)))
 
     def getlocalroot(self):
-        xforms = [os.path.expanduser]
+        xforms = [os.path.expanduser, os.path.expandvars]
         return self.getconf_xform('localfolders', xforms)
 
     def debug(self, msg):


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [] Code is tested (provide details).

### References

- Issue #no_space

### Additional information



Commit e51ed80e claims to add tilde and environment variable expansion
to multiple locations including Repository.localfolders. However, this
particular options seems to have been missed in that commit, and
apparently no one noticed till date

Signed-off-by: Darshit Shah <darnir@gmail.com>