### PR TITLE
init: register SIGABRT and handle as per SIGUSR2

### DIFF
--- a/offlineimap/init.py
+++ b/offlineimap/init.py
@@ -416,7 +416,7 @@ class OfflineImap(object):
             if sig == signal.SIGUSR1:
                 # tell each account to stop sleeping
                 accounts.Account.set_abort_event(self.config, 1)
-            elif sig == signal.SIGUSR2:
+            elif sig in (signal.SIGUSR2, signal.SIGABRT):
                 # tell each account to stop looping
                 getglobalui().warn("Terminating after this sync...")
                 accounts.Account.set_abort_event(self.config, 2)
@@ -442,6 +442,7 @@ class OfflineImap(object):
             signal.signal(signal.SIGHUP, sig_handler)
             signal.signal(signal.SIGUSR1, sig_handler)
             signal.signal(signal.SIGUSR2, sig_handler)
+            signal.signal(signal.SIGABRT, sig_handler)
             signal.signal(signal.SIGTERM, sig_handler)
             signal.signal(signal.SIGINT, sig_handler)
             signal.signal(signal.SIGQUIT, sig_handler)


### PR DESCRIPTION
systemd supports a watchdog (via the WatchdogSec service file option)
which will send the program a SIGABRT when the timer expires, however
currently this causes offlineimap to be killed immediately.

This patch registers SIGABRT and handles it in the same manner as
SIGUSR2, so that the current synchronisation is completed before the
program exits safely.

This makes offlineimap more flexible and robust for persistent setups
that make use of holdconnectionopen and autorefresh options.

For example, it may be useful in assisting with the occasional
situation where offlineimap may not return successfully after a suspend
and resume.

To make use of this, users could add the following to the [Service]
section of their systemd offlineimap service file (restart every 5
minutes):

Restart=on-watchdog
WatchdogSec=300

Signed-off-by: Chris Smart <mail@csmart.io>

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested - I have been using this setting for a few days (applied on top of **6.7.0**), and have observed systemd restarting offlineimap via the watchdog. The systemd log shows that offlineimap is finalising the sync before it is stopped. It has also helped offlineimap to restart after a suspend/resume cycle where occasionally I get some NOOP errors.

### References

- Issue #no_space

### Additional information


