### PR TITLE
generalize get-repository.sh

### DIFF
--- a/scripts/get-repository.sh
+++ b/scripts/get-repository.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
-# Licence: this file is in the public deomain.
+# Licence: this file is in the public domain.
 #
 # Download and configure the repositories of the website or wiki.
 


### PR DESCRIPTION
fixed type
added a platform independent call to bash

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


