### PR TITLE
Fix ipv6 configuration handling

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -222,7 +222,7 @@ class IMAPRepository(BaseRepository):
         return self.getconfint('remoteport', None)
 
     def getipv6(self):
-        return self.getconfboolean('ipv6', False)
+        return self.getconfboolean('ipv6', None)
 
     def getssl(self):
         return self.getconfboolean('ssl', True)


### PR DESCRIPTION
According to documentation and the code, the following behavior is expected:

ipv6 = no
    AF_INET is used

ipv6 = yes
    AF_INET6 is used

ipv6 undefined
    AF_UNDEF is used

Unfortunately the code parsing the "ipv6" configuration option was
returning "False" rather than "None" when failing to locate the option,
making it impossible to detect whether "ipv6" isn't set or if it was set
to "false" and leading offlineimap to use AF_INET for the connection.

This fixes the use of offlineimap on hosts that occasionaly are
connected to IPv6-only networks.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information

I've manually tested this code in the following setups:

#### IPv6-only machine
ipv6=yes => works (same as before)
ipv6=no => fails (expected, same as before)
no ipv6 config => works (improvement)

#### IPv4-only machine
ipv6=yes => fails (expected, same as before)
ipv6=no => works (same as before
no ipv6 config => works (same as before)

#### Dual-stack machine
ipv6=yes => works (same as before)
ipv6=no => works (same as before
no ipv6 config => works (same as before)
