### PR TITLE
Dryrun warning

### DIFF
--- a/docs/offlineimap.known_issues.txt
+++ b/docs/offlineimap.known_issues.txt
@@ -151,3 +151,10 @@ See <https://developers.google.com/analytics/devguides/config/mgmt/v3/authorizat
 and <https://developers.google.com/identity/protocols/OAuth2#expiration>
 to know more.
 
+* Dry-run crashes upon encountering new local or remote folders
++
+`--dry-run` will die with `getfolder() asked for a nonexisting folder` when it
+encounters folders that it has not previously synced. This is unfortunately a
+result of the way that OfflineIMAP expects folders to look, and is nontrivial
+to fix. In the meantime, dry run should only be used when the same sets of 
+folders exist on the local and remote sides of the sync. 


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #52

### Additional information


