### PR TITLE
Prevent synchronization of identical folders from multiple threads

### DIFF
--- a/offlineimap/accounts.py
+++ b/offlineimap/accounts.py
@@ -528,6 +528,9 @@ def syncfolder(account, remotefolder, quick):
         # Load local folder.
         localfolder = account.get_local_folder(remotefolder)
 
+        localfolder.mutex.acquire()
+        remotefolder.mutex.acquire()
+
         # Add the folder to the mbnames mailboxes.
         mbnames.add(account.name, localrepos.getlocalroot(),
             localfolder.getname())
@@ -616,3 +619,5 @@ def syncfolder(account, remotefolder, quick):
             if folder in locals():
                 locals()[folder].dropmessagelistcache()
         statusfolder.closefiles()
+        remotefolder.mutex.release()
+        localfolder.mutex.release()

--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -19,6 +19,7 @@ import os.path
 import re
 import time
 from sys import exc_info
+from threading import Lock
 
 from offlineimap import threadutil
 from offlineimap.ui import getglobalui
@@ -90,6 +91,8 @@ class BaseFolder(object):
             self.__syncmessagesto_delete,
             self.__syncmessagesto_flags,
         ]
+
+        self.mutex = Lock()
 
     def getname(self):
         """Returns name"""


### PR DESCRIPTION
Use a mutex to lock both local and remote folders before doing
synchronization.  This prevents IDLE threads from downloading the same
messages as autorefresh threads (this could have resulted in
downloading new messages twice, or reading "one message past the last
one" which in some cases created a duplicate an IMAP folder's first
message).  Also prevents IDLE threads from reading new messages before
the autorefresh thread finishes synchronization.

Fixes #421.

Signed-off-by: Michael Hohmuth <hohmuth@sax.de>