### PR TITLE
doc: Fix typo in offlineimap.1 man page

### DIFF
--- a/docs/offlineimap.known_issues.txt
+++ b/docs/offlineimap.known_issues.txt
@@ -120,7 +120,7 @@ Sometimes, you might hit one of the following error:
 - oauth2handler got: {u'error': u'invalid_grant'}
 
 +
-In such case, we had report that generating a new refesh token from the same
+In such case, we had reports that generating a new refresh token from the same
 client ID and secret can help.
 +
 .Google documentation on "invalid_grant"


### PR DESCRIPTION
### Peer reviews

Trick to [fetch the pull request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested.