### PR TITLE
Reliably detect internet connected.

### DIFF
--- a/contrib/internetConnected.py
+++ b/contrib/internetConnected.py
@@ -1,19 +1,10 @@
 
-import socket
-def internetConnected(host="8.8.8.8", port=53, timeout=3):
-   """
-   Simple function to quickly check, are we connected to the internet.
-   Needed to detect when waking up from sleep or returning from suspend.
-   Network can take a few seconds to reconnect. Sometimes longer.
-   Default connect to host: 8.8.8.8 (google-public-dns-a.google.com)
-   OpenPort: 53/tcp
-   Service: domain (DNS/TCP)
-   Average time to check is less than 0.2 second (200 ms).
-   """
+import requests
+
+def internetConnected(httpshost="www.google.com"):
    try:
-     socket.setdefaulttimeout(timeout)
-     socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
-     return True
-   except Exception as ex:
-     print ex.message
-     return False
+    r = requests.get("https://" + httpshost)
+  except Exception as ex:
+    return False
+  return True
+

--- a/contrib/internetConnected.py
+++ b/contrib/internetConnected.py
@@ -1,0 +1,19 @@
+
+import socket
+def internetConnected(host="8.8.8.8", port=53, timeout=3):
+   """
+   Simple function to quickly check, are we connected to the internet.
+   Needed to detect when waking up from sleep or returning from suspend.
+   Network can take a few seconds to reconnect. Sometimes longer.
+   Default connect to host: 8.8.8.8 (google-public-dns-a.google.com)
+   OpenPort: 53/tcp
+   Service: domain (DNS/TCP)
+   Average time to check is less than 0.2 second (200 ms).
+   """
+   try:
+     socket.setdefaulttimeout(timeout)
+     socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
+     return True
+   except Exception as ex:
+     print ex.message
+     return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # Requirements
 six
+requests


### PR DESCRIPTION
Simple function to reliably detect is the internet connected.
To help break out of the infinite loop bug.
Break out of waiting forever on a network interface which has temporarily got no internet connectivity.
*** This is reliable because it verifies the https certificate.  Only the real https site can provide the real https cert.  A captive portal cannot, it's protected by cryptography so it's for practical reasons impossible, good enough for our purposes, to solve this terrible hang bug. ***

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References
- Previous PR #440
- Issue #125 
- Many other Issues related to:
 * laptop waking up from sleep power mode, 
 * temporary disconnect from internet, and 
 * infinite loop.

### Additional information


