### PR TITLE
Acquire lock before updating the CursesLogHandler window

### DIFF
--- a/offlineimap/ui/Curses.py
+++ b/offlineimap/ui/Curses.py
@@ -315,11 +315,11 @@ class CursesLogHandler(logging.StreamHandler):
             y,x = self.ui.logwin.getyx()
             if y or x: self.ui.logwin.addch(10) # no \n before 1st item
             self.ui.logwin.addstr(log_str, color)
+            self.ui.logwin.noutrefresh()
+            self.ui.stdscr.refresh()
         finally:
             self.ui.unlock()
             self.ui.tframe_lock.release()
-        self.ui.logwin.noutrefresh()
-        self.ui.stdscr.refresh()
 
 class Blinkenlights(UIBase, CursesUtil):
     """Curses-cased fancy UI.
@@ -611,11 +611,12 @@ class Blinkenlights(UIBase, CursesUtil):
             color = curses.A_REVERSE
         self.bannerwin.clear() # Delete old content (eg before resizes)
         self.bannerwin.bkgd(' ', color) # Fill background with that color
-        string = "%s %s"% (offlineimap.__productname__,
-            offlineimap.__version__)
-        self.bannerwin.addstr(0, 0, string, color)
-        self.bannerwin.addstr(0, self.width -len(offlineimap.__copyright__) -1,
-                              offlineimap.__copyright__, color)
+        string = "%s %s" % (offlineimap.__productname__,
+                            offlineimap.__version__)
+        spaces = " " * max(1, (self.width - len(offlineimap.__copyright__)
+                               - len(string) - 1))
+        string = "%s%s%s" % (string, spaces, offlineimap.__copyright__)
+        self.bannerwin.addnstr(0, 0, string, self.width - 1, color)
         self.bannerwin.noutrefresh()
 
     def draw_logwin(self):


### PR DESCRIPTION
Make sure that we refresh the screen atomically, since the emit()
function may be called by more that one threads at a time.

Also, modify the draw_bannerwin() method which used to fail in case the
window would become too small. Make sure that the provided offsets to
the window.addstr() method are properly bounded.

Closes #160: blinkenlights display is broken
Signed-off-by: Ilias Tsitsimpis <i.tsitsimpis@gmail.com>

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (see #160).

### References

- Issue #160 