### PR TITLE
Fixed typo in doc: tls_1_2 => tls1_2

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -739,7 +739,7 @@ remotehost = examplehost
 #
 # It is best to leave this unset, in which case the correct version will be
 # automatically detected. In rare cases, it may be necessary to specify a
-# particular version from: tls1, tls1_1, tls_1_2, ssl3, ssl23.
+# particular version from: tls1, tls1_1, tls1_2, ssl3, ssl23.
 #
 # tls1_1 and tls1_2 are available with OpenSSL since v1.0.1.
 #


### PR DESCRIPTION
tls1_2 matches the string in offlineimap/bundled_imaplib2.py and
offlineimap fails when using tls_1_2:
("Invalid SSL version 'tls_1_2' requested for tls_version 'tls_secure'",)

Signed-off-by: Maximilian Kaul <maximilian+git@maximiliankaul.de>

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


