### PR TITLE
Remove SQLite performance improvement docs, extend changelog entry.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,8 +19,13 @@ Note to mainainers:
 
 #### Notes
 
-The most important change is the removal of the status_backend configuration
-option and that's why we're moving to v7.1.0.
+The most important change is that the syncronisation status cache is now stored
+in SQLite and the `status_backend` option is no longer configurable. You may
+safely remove this option from your configuration. This change is why we're
+moving to v7.1.0. If you were previously using the default `plain` backend, you
+may want to delete the old cache directory in
+'<metadata>/Account-<account>/LocalStatus' manually (the sqlite cache stands in
+the 'LocalStatus-sqlite' folder).
 
 There are other small bug fixes and improvements. However, the codebase didn't
 change much since v7.0.14.

--- a/docs/offlineimap.txt
+++ b/docs/offlineimap.txt
@@ -220,24 +220,7 @@ monthly folders, and ignore every folder that is more than 2-3 months old,
 this lets me only inspect a fraction of my Mails on every sync. If you haven't
 done this yet, do it :). See the 'folderfilter' section in 'offlineimap.conf'.
 
-3. The sqlite cache.
-+
-OfflineImap caches the state of the synchronisation to e.g. be able to determine
-if a mail has been added or deleted on either side.
-+
-The historical status cache is a plain text file that writes out the complete
-file for each single new message (or even changed flag) to a temporary file. If
-you have plenty of files in a folder, this is a few hundred kilo to megabytes
-for each mail and is bound to make things slow. The latest status cache
-is sqlite. This saves plenty of disk activity. The sqlite engine and the Python
-sqlite module must be installed. The historical plain status cache is not
-supported anymore.
-+
-If you switch the backend from plain to sqlite, you may want to delete the old
-cache directory in '<metadata>/Account-<account>/LocalStatus' manually (the
-sqlite cache stands in the 'LocalStatus-sqlite' folder).
-
-4. Use quick sync.
+3. Use quick sync.
 +
 A regular sync will request all flags and all UIDs of all mails in each folder
 which takes quite some time. A quick sync only compares the number of
@@ -247,7 +230,7 @@ Maildir side of things though). A quick sync on my smallish account will take
 sync once a day, and does quick syncs `-q' only synchronizing the `-f INBOX'
 in between.
 
-5. Turn off fsync.
+4. Turn off fsync.
 +
 In the '[general]' section you can set fsync to 'True' or 'False'. If you want to
 play 110% safe and wait for all operations to hit the disk before continuing,

--- a/offlineimap/repository/LocalStatus.py
+++ b/offlineimap/repository/LocalStatus.py
@@ -41,7 +41,7 @@ class LocalStatusRepository(BaseRepository):
         if self.account.getconf('status_backend', None) is not None:
             raise OfflineImapError(
                 "the 'status_backend' configuration option is not supported"
-                " anymore; please, remove this configuration option.",
+                " anymore and may be safely removed.",
                 OfflineImapError.ERROR.REPO
             )
         # Set class and root for sqlite.


### PR DESCRIPTION
After upgrading to v7.1.0, and receiving an error message about
`status_backend`, I wasn't sure whether I was safe to simply remove this
configuration, or whether it had been moved somewhere else, given that SQLite
was still mentioned in the performance improvement notes.

Looking at the code, I believe that this section just needs to be removed from
the performance improvement notes.

Signed-off-by: Ben Sturmfels <ben@sturm.com.au>

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [] Code is tested (provide details).

