### PR TITLE
Secure HTTPS test internet is connected with urllib3 and certifi

### DIFF
--- a/contrib/internet-urllib3.py
+++ b/contrib/internet-urllib3.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import urllib3
+import certifi
+
+def isInternetConnected(url="www.ietf.org"):
+  result = False
+  http = urllib3.PoolManager(
+    cert_reqs='CERT_REQUIRED', # Force certificate check.
+    ca_certs=certifi.where(),  # Path to the Certifi bundle.
+  )
+  try:
+    r = http.request('HEAD', 'https://' + url)
+    result = True
+  except Exception as e:  # urllib3.exceptions.SSLError
+    result = False
+  return result
+
+print isInternetConnected()


### PR DESCRIPTION
> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- A first step toward solving issue 447 (reliably detect internet detected). 

### Additional information

Runs from command line.  
Prints True if internet is connected. 
Prints False if internet is disconnected.
Uses `certifi` library to detect location of `cacert.pem` depending on operating system.
Uses `urllib3` to perform secure connection over `https` to remote server to verify internet is connected and with valid certificate, this proves internet is truly connected.
