### PR TITLE
docs: update the instructions for creating OAuth projects for GMail

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -856,15 +856,25 @@ remoteuser = username
 # See below to learn how to get those.
 #
 # Specify the OAuth2 client id and secret to use for the connection..
-# Here's how to register an OAuth2 client for Gmail, as of 10-2-2016:
-#    - Go to the Google developer console
-#         https://console.developers.google.com/project
-#    - Create a new project
+# Here's how to register an OAuth2 client for Gmail, as of 2017-05-15:
+#    - Go to the Gmail API overview console
+#         https://console.developers.google.com/apis/api/gmail.googleapis.com/overview
+#    - Create a new project, name doesn't matter, e.g. 'gmail-sync-bob'
 #    - In API & Auth, select Credentials
-#    - Setup the OAuth Consent Screen
-#    - Then add Credentials of type OAuth 2.0 Client ID
-#    - Choose application type Other; type in a name for your client
-#    - You now have a client ID and client secret
+#    - Once created, click 'Enable'
+#    - Click 'Create credentials' in the enabled API overview
+
+#    - In 'Add credentials to your project' select 'Gmail API' as the
+#      API type, and 'Other UI ...' (not 'Other non-UI ...') for
+#      'Where will you be calling the API from?'. For 'What data will
+#      you be accessing?' select 'User data'.
+#    - Click 'What credentials do I need?'
+#    - Create an arbitrary 'Create an OAuth 2.0 client ID',
+#      e.g. 'gmail-sync-bob-client'. For 'Set up the OAuth 2.0 consent
+#      screen' select an arbitrary 'Product name shown to users',
+#      e.g. 'gmail-sync-bob-client' & click 'Continue'.
+#    - This gives  you your client  ID displayed on the  screen. Click
+#      'Download' to get a JSON file that also has the client secret.
 #
 #oauth2_client_id = YOUR_CLIENT_ID
 #oauth2_client_secret = YOUR_CLIENT_SECRET


### PR DESCRIPTION
I just went through this whole thing now, wasn't successful because
the referenced oauth tools don't seem to work, but this covers changes
in the Google UI since last time.