### PR TITLE
Remove unused watchdog functionality

### DIFF
--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -3,8 +3,8 @@ layout: page
 title: Integrating OfflineIMAP into systemd
 author: Ben Boeckel
 date: 2015-03-22
-contributors: Abdo Roig-Maranges
-updated: 2015-03-25
+contributors: Abdo Roig-Maranges, benutzer193
+updated: 2017-06-01
 ---
 
 <!-- This file is copied to the website by script. -->
@@ -25,25 +25,4 @@ These unit files are installed as being enabled via a `mail.target` unit which
 is intended to be a catch-all for mail-related unit files. A simple
 `mail.target` file is also provided.
 
-## Signals
-
-Systemd supports a watchdog (via the WatchdogSec service file option) which
-will send the program a SIGABRT when the timer expires.
-
-Offlineimap handles it in the same manner as SIGUSR2, so that the current
-synchronisation is completed before the program exits safely.
-
-This makes offlineimap more flexible and robust for persistent setups that make
-use of holdconnectionopen and autorefresh options.
-
-For example, it may be useful in assisting with the occasional situation where
-offlineimap may not return successfully after a suspend and resume.
-
-To make use of this, users could add the following to the [Service] section of
-their corresponding systemd offlineimap-oneshot service file (restart every 5 minutes):
-
-``` conf
-Restart=on-watchdog
-WatchdogSec=300
-```
 

--- a/contrib/systemd/offlineimap-oneshot.service
+++ b/contrib/systemd/offlineimap-oneshot.service
@@ -5,10 +5,10 @@ Documentation=man:offlineimap(1)
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/offlineimap -o -u syslog
-# Give 12 seconds for offlineimap to gracefully stop before hard killing it.
-TimeoutStopSec=12
-#Restart=on-watchdog
-#WatchdogSec=300
+# Give 120 seconds for offlineimap to gracefully stop before hard killing it.
+TimeoutStopSec=120
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=mail.target

--- a/contrib/systemd/offlineimap-oneshot@.service
+++ b/contrib/systemd/offlineimap-oneshot@.service
@@ -5,8 +5,11 @@ Documentation=man:offlineimap(1)
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/offlineimap -o -a %i -u syslog
-#Restart=on-watchdog
-#WatchdogSec=300
+# Give 120 seconds for offlineimap to gracefully stop before hard killing it.
+TimeoutStopSec=120
+Restart=on-failure
+RestartSec=60
+
 
 [Install]
 WantedBy=mail.target

--- a/contrib/systemd/offlineimap.service
+++ b/contrib/systemd/offlineimap.service
@@ -4,6 +4,8 @@ Documentation=man:offlineimap(1)
 
 [Service]
 ExecStart=/usr/bin/offlineimap -u syslog
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=mail.target

--- a/contrib/systemd/offlineimap@.service
+++ b/contrib/systemd/offlineimap@.service
@@ -4,6 +4,8 @@ Documentation=man:offlineimap(1)
 
 [Service]
 ExecStart=/usr/bin/offlineimap -a %i -u syslog
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=mail.target


### PR DESCRIPTION
Remove unused watchdog functionality, add restart on failure and increase timeout to kill service.

Signed-off-by: benutzer193 <registerbn@gmail.com>

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #476 

### Additional information


