### PR TITLE
Fixed Typo

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -643,7 +643,7 @@ remotehost = examplehost
 # This option stands in the [Repository RemoteExample] section.
 #
 # Whether or not to use STARTTLS. STARTTLS allows to upgrade a plain connection
-# to TLS or SSL after negociation with the server. While a server might pretend
+# to TLS or SSL after negotiation with the server. While a server might pretend
 # to support STARTTLS, the communication might not be properly established or
 # the secure tunnel might be broken in some way. In this case you might want to
 # disable STARTTLS. Unless you hit issues with STARTTLS, you are strongly


### PR DESCRIPTION
Fixed typo in the default config file, I changed the word "negociation" to "negotiation" as the original author intended.

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [] Code changes follow the style of the files they change.
- [] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


