### PR TITLE
Fix #503 hostname shouldn't be required by any tunnel

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -92,7 +92,7 @@ class IMAPServer(object):
             self.af = socket.AF_INET
         else:
             self.af = socket.AF_UNSPEC
-        self.hostname = None if self.transport_tunnel else repos.gethost()
+        self.hostname = None if self.transport_tunnel or self.preauth_tunnel else repos.gethost()
         self.port = repos.getport()
         if self.port is None:
             self.port = 993 if self.usessl else 143


### PR DESCRIPTION
Fix #503 if any tunnel (preauth_tunnel or transport_tunnel) the hostname should not be required

It's required to modify my change 1ce596d7135e58186f14b7b193aa2100e5f296fa because a hostname shouldn't be needed if any tunnel is used. Both tunnels provide a regular IMAP interface which is used by offlineimap.

Signed-off-by: Thomas Merkel <tm@core.io>

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #503 

### Additional information


