### PR TITLE
Add missing space to output string

### DIFF
--- a/offlineimap/folder/LocalStatus.py
+++ b/offlineimap/folder/LocalStatus.py
@@ -119,7 +119,7 @@ class LocalStatusFolder(BaseFolder):
 
             # Convert from format v1.
             elif line == (self.magicline % 1):
-                self.ui._msg('Upgrading LocalStatus cache from version 1'
+                self.ui._msg('Upgrading LocalStatus cache from version 1 '
                     'to version 2 for %s:%s'% (self.repository, self))
                 self.readstatus_v1(cachefd)
                 cachefd.close()


### PR DESCRIPTION
It was previously printing "Upgrading LocalStatus cache from version 1to version 2 for XXX"

> This v1.0 template stands in `.github/`.

### Peer reviews

Trick to [fetch the pull
request](https://help.github.com/articles/checking-out-pull-requests-locally):
there is a (read-only) `refs/pull/` namespace.

``` bash
git fetch OFFICIAL_REPOSITORY_NAME pull/PULL_ID/head:LOCAL_BRANCH_NAME
```

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


