### PR TITLE
Correct typographical errors in offlineimap.conf

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -365,7 +365,7 @@ remoterepository = RemoteExample
 # This option stands in the [Account Test] section.
 #
 # Maildir file format uses colon (:) separator between uniq name and info.
-# Unfortunatelly colon is not allowed character in windows file name. If you
+# Unfortunately colon is not allowed character in windows file name. If you
 # enable maildir-windows-compatible option, Offlineimap will be able to store
 # messages on windows drive, but you will probably loose compatibility with
 # other programs working with the maildir.
@@ -420,7 +420,7 @@ remoterepository = RemoteExample
 #
 # This knob is respected only by IMAP-based accounts.  Value of labelsheader
 # for GMail-based accounts is automatically added to this list, you don't
-# need to specify it explicitely.
+# need to specify it explicitly.
 #
 # Use ASCII characters only.
 #
@@ -429,7 +429,7 @@ remoterepository = RemoteExample
 
 # This option stands in the [Account Test] section.
 #
-# Use proxy connection for this account. Usefull to bypass the GFW in China.
+# Use proxy connection for this account. Useful to bypass the GFW in China.
 # To specify a proxy connection, join proxy type, host and port with colons.
 # Available proxy types are SOCKS5, SOCKS4, HTTP.
 # You also need to install PySocks through pip.
@@ -452,7 +452,7 @@ remoterepository = RemoteExample
 # in order to have nicely readable UTF-8 folder names in the local copy.
 #
 # WARNING: with this option enabled:
-# - compatibility with any other version is NOT GUARANTED (including newer);
+# - compatibility with any other version is NOT GUARANTEED (including newer);
 # - existing set-ups will probably break.
 # - no support is provided.
 #
@@ -901,7 +901,7 @@ remoteuser = username
 # For Gmail (and maybe others), XOAUTH2 requires ssl. This means that STARTTLS
 # won't work and that Offlineimap will perform certificate validation.  IOW, the
 # following configuration is used:
-#   - sslcacertfile: MUST BE correclty configured
+#   - sslcacertfile: MUST BE correctly configured
 #   - ssl = yes (optional, will be used anyway)
 #   - starttls = no (optional, will be tried but won't work anyway)
 #
@@ -997,7 +997,7 @@ remoteuser = username
 #
 # 4. With a preauth tunnel.  With this method, you invoke an external
 #    program that is guaranteed *NOT* to ask for a password, but rather
-#    to read from stdin and write to stdout an IMAP procotol stream that
+#    to read from stdin and write to stdout an IMAP protocol stream that
 #    begins life in the PREAUTH state.  When you use a tunnel, you do
 #    NOT specify a user or password (if you do, they'll be ignored.)
 #    Instead, you specify a preauthtunnel, as this example illustrates
@@ -1052,7 +1052,7 @@ remoteuser = username
 #
 # This is most commonly needed with UW IMAP, where you might need to specify the
 # directory in which your mail is stored. The 'reference' value will be prefixed
-# to all folder paths refering to that repository. E.g. accessing folder 'INBOX'
+# to all folder paths referring to that repository. E.g. accessing folder 'INBOX'
 # with "reference = Mail" will try to access Mail/INBOX.
 #
 # The nametrans and folderfilter functions will apply to the full path,
@@ -1394,7 +1394,7 @@ remoteuser = username
 #
 #  http://mail.google.com/support/bin/answer.py?answer=78799&topic=12814
 #
-# This means ssl is enabled and must be configured correcly when connecting to
+# This means ssl is enabled and must be configured correctly when connecting to
 # Gmail.
 #
 # In addition we provide defaults for "oauth2_request_url",


### PR DESCRIPTION
Corrections to some typographical errors errors that I noticed in the `offlineimap.conf` file comments.

All changes are in comments, so most of the checklist below is N/A.

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [ ] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [ ] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

- None
