### PR TITLE
Longer hash support

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -787,10 +787,11 @@ remotehost = examplehost
 #
 # In Windows, Microsoft uses the term "thumbprint" instead of "fingerprint".
 #
+# Supported fingerprint hashes are sha512, sha384, sha256, sha224 and sha1.
 # Fingerprints must be in hexadecimal form without leading '0x':
 # 40 hex digits like bbfe29cf97acb204591edbafe0aa8c8f914287c9.
 #
-#cert_fingerprint = <SHA1_of_server_certificate_here>[, <another_SHA1>]
+#cert_fingerprint = <SHAn_of_server_certificate_here>[, <another_SHAm>]
 
 
 # This option stands in the [Repository RemoteExample] section.

--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -207,12 +207,12 @@ class WrappedIMAP4_SSL(UsefulIMAPMixIn, IMAP4_SSL):
             # compare fingerprints
             matches = [(server_fingerprint in self._fingerprint) for server_fingerprint in server_fingerprints]
             if not any(matches):
-                raise OfflineImapError("Server SSL fingerprint '%s' "
+                raise OfflineImapError("Server SSL fingerprint(s) '%s' "
                       "for hostname '%s' "
                       "does not match configured fingerprint(s) %s.  "
                       "Please verify and set 'cert_fingerprint' accordingly "
                       "if not set yet."%
-                      (server_fingerprints, host, self._fingerprint),
+                      (list(zip([hash.__name__ for hash in hashes], server_fingerprints)), host, self._fingerprint),
                       OfflineImapError.ERROR.REPO)
 
 

--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -212,7 +212,7 @@ class WrappedIMAP4_SSL(UsefulIMAPMixIn, IMAP4_SSL):
                       "does not match configured fingerprint(s) %s.  "
                       "Please verify and set 'cert_fingerprint' accordingly "
                       "if not set yet."%
-                      (list(zip([hash.__name__ for hash in hashes], server_fingerprints)), host, self._fingerprint),
+                      (zip([hash.__name__ for hash in hashes], server_fingerprints), host, self._fingerprint),
                       OfflineImapError.ERROR.REPO)
 
 


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #521 

### Additional information

This is to add support for longer hash functions to calculate the server certificate fingerprint. I have modified the exception message to display what possible hashes the server certificate may have, along with the name of the different hashes.

I have tested this locally for an email account of mine with sha512.

