### PR TITLE
Allow colon separated fingerprints in configuration file

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -787,8 +787,11 @@ remotehost = examplehost
 #
 # In Windows, Microsoft uses the term "thumbprint" instead of "fingerprint".
 #
-# Fingerprints must be in hexadecimal form without leading '0x':
-# 40 hex digits like bbfe29cf97acb204591edbafe0aa8c8f914287c9.
+# Fingerprints must be in hexadecimal form without leading '0x', and may have
+# the separating colons. This is non case-sensitive.
+# Examples:
+# sha1 "bbfe29cf97acb204591edbafe0aa8c8f914287c9".
+# sha1 with colons "BB:FE:29:CF:97:AC:B2:04:59:1E:DB:AF:E0:AA:8C:8F:91:42:87:C9"
 #
 #cert_fingerprint = <SHA1_of_server_certificate_here>[, <another_SHA1>]
 

--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -293,7 +293,7 @@ class IMAPRepository(BaseRepository):
         comma-separated fingerprints in hex form."""
 
         value = self.getconf('cert_fingerprint', "")
-        return [f.strip().lower() for f in value.split(',') if f]
+        return [f.strip().lower().replace(":", "") for f in value.split(',') if f]
 
     def setoauth2_request_url(self, url):
         self.oauth2_request_url = url


### PR DESCRIPTION
> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #521, I mention this feature in a comment.

### Additional information
Tools like `openssl` return fingerprints in a colon separated format:
```
$ openssl x509 -in certfile.pem -sha1 -noout -fingerprint
SHA1 Fingerprint=D0:83:13:3F:99:99:0F:80:0A:B5:58:C4:51:27:13:81:45:8E:74:F0
```
This minor change allows users to directly copy and paste the fingerprint from this kind of format into their configuration file. Existing configurations will not be affected.

Tested locally with an existing configuration.