### PR TITLE
TLS Level not setable to tls_secure when ssl disabled

### DIFF
--- a/offlineimap.conf
+++ b/offlineimap.conf
@@ -844,8 +844,8 @@ remotehost = examplehost
 #   - ssl3 (less desirable than tls1)
 #   - ssl23 (can fallback up to ssl3)
 #
-# When tls_level is not set to tls_compat, the ssl_version configuration option
-# must be explicitly set.
+# When tls_level is not set to tls_compat and ssl is still enabled,
+# the ssl_version configuration option must be explicitly set.
 #
 #tls_level = tls_compat
 

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -100,7 +100,9 @@ class IMAPServer(object):
         self.sslversion = repos.getsslversion()
         self.starttls = repos.getstarttls()
 
-        if self.tlslevel is not "tls_compat" and self.sslversion is None:
+        if self.usessl \
+           and self.tlslevel is not "tls_compat" \
+           and self.sslversion is None:
             raise Exception("When 'tls_level' is not 'tls_compat' "
                 "the 'ssl_version' must be set explicitly.")
 

--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -101,7 +101,7 @@ class IMAPServer(object):
         self.starttls = repos.getstarttls()
 
         if self.tlslevel is not "tls_compat" and self.sslversion is None:
-            raise Exception("When 'tls_version' is not 'tls_compat' "
+            raise Exception("When 'tls_level' is not 'tls_compat' "
                 "the 'ssl_version' must be set explicitly.")
 
         self.oauth2_refresh_token = repos.getoauth2_refresh_token()


### PR DESCRIPTION
### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### Additional information

While installing and configuring offlineimap for myself, I came across this weird exception.

The important bit of the configuration:

```
[Repository Remote]
type = IMAP

starttls = yes
ssl = no
tls_level = tls_secure
# required to workaround on current master:
#ssl_version = ssl23
```