### PR TITLE
Add Archlinux to list of supported distros

### DIFF
--- a/offlineimap/utils/distro.py
+++ b/offlineimap/utils/distro.py
@@ -26,6 +26,7 @@ __DEF_OS_LOCATIONS = {
     'linux-redhat': '/etc/pki/tls/certs/ca-bundle.crt',
     'linux-suse': '/etc/ssl/ca-bundle.pem',
     'linux-opensuse': '/etc/ssl/ca-bundle.pem',
+    'linux-arch': '/etc/ssl/certs/ca-certificates.crt',
 }
 
 


### PR DESCRIPTION
get_os_name returns linux-arch on Archlinux, so add a line for linux-arch to __DEF_OS_LOCATIONS.

Signed-off-by: Philippe Loctaux <loctauxphilippe@gmail.com>

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #568, but it only fixes only one part of the issue. the issue will be fully resolved with having a default ssl certfile for osx with homebrew.

### Additional information

let me know if i did something wrong