### PR TITLE
Added ssl certfile on osx for openssl pacakge on homebrew

### DIFF
--- a/offlineimap/utils/distro.py
+++ b/offlineimap/utils/distro.py
@@ -18,6 +18,8 @@ __DEF_OS_LOCATIONS = {
     'darwin': [
       # MacPorts, port curl-ca-bundle
       '/opt/local/share/curl/curl-ca-bundle.crt',
+      # homebrew, package openssl
+      '/usr/local/etc/openssl/cert.pem',
     ],
     'linux-ubuntu': '/etc/ssl/certs/ca-certificates.crt',
     'linux-debian': '/etc/ssl/certs/ca-certificates.crt',


### PR DESCRIPTION
A certfile was already specified for osx but only with MacPorts,
this patch adds the certfile given with the package `openssl` with
homebrew.

You can get more info with the command `brew info openssl` on osx with
homebrew and openssl installed.

Signed-off-by: Philippe Loctaux <loctauxphilippe@gmail.com>

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #568, fixes this issue.

### Additional information

let me know if i did something wrong, thanks.