### PR TITLE
Handle empty token with complete GSSAPI context

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -274,6 +274,13 @@ class IMAPServer(object):
             if not self.gss_vc.complete:
                 response = self.gss_vc.step(token)
                 return response if response else ""
+            elif token is None:
+                # uh... context is complete, so there's no negotiation we can
+                # do.  But we also don't have a token, so we can't send any
+                # kind of response.  Empirically, some (but not all) servers
+                # seem to put us in this state, and seem fine with getting no
+                # GSSAPI content in response, so give it to them.
+                return ""
 
             # Don't bother checking qop because we're over a TLS channel
             # already.  But hey, if some server started encrypting tomorrow,


### PR DESCRIPTION
This fixes a potential traceback when we try to unwrap(None).

Tested-by: Stefan Hajnoczi <stefanha@redhat.com>
Signed-off-by: Robbie Harwood <rharwood@redhat.com>

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Downstream: [rhbz#1646916](https://bugzilla.redhat.com/show_bug.cgi?id=1646916)

### Additional information

Originally reported downstream in Fedora; patch tested there.  Thanks!