### PR TITLE
Add checks in curses ui for small windows

### DIFF
--- a/offlineimap/ui/Curses.py
+++ b/offlineimap/ui/Curses.py
@@ -137,7 +137,13 @@ class CursesAccountFrame:
         sleepstr = '%3d:%02d'% (secs // 60, secs % 60) if secs else 'active'
         accstr = '%s: [%s] %12.12s: '% (self.acc_num, sleepstr, self.account)
 
-        self.ui.exec_locked(self.window.addstr, 0, 0, accstr)
+        def addstr():
+            try:
+                self.window.addstr(0, 0, accstr)
+            except curses.error as e: # Occurs when the terminal is very small
+                pass
+        self.ui.exec_locked(addstr);
+
         self.location = len(accstr)
 
     def setwindow(self, curses_win, acc_num):
@@ -211,7 +217,10 @@ class CursesThreadFrame:
 
     def display(self):
         def locked_display():
-            self.window.addch(self.y, self.x, '@', self.curses_color)
+            try:
+                self.window.addch(self.y, self.x, '@', self.curses_color)
+            except curses.error: # Occurs when the terminal is very small
+                pass
             self.window.refresh()
         # lock the curses IO while fudging stuff
         self.ui.exec_locked(locked_display)


### PR DESCRIPTION
`addch()` and `addstr()` throw an exception if text has to be printed
outside of the window. This may occur if the terminal is very small (i.e. <30 columns).
Such erroneous prints are no-ops now.

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #595 

### Additional information




