### PR TITLE
use portable locker to support cygwin in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Bugs, issues and contributions can be requested to both the mailing list or the
 * six (required)
 * imaplib2 >= 2.57 (optional)
 * gssapi (optional), for Kerberos authentication
-
+* portalocker(optional), if you need to run offlineimap in Cygwin for Windows
 
 ## Documentation
 

--- a/offlineimap/accounts.py
+++ b/offlineimap/accounts.py
@@ -34,7 +34,7 @@ SYNC_MUTEXES = {}
 SYNC_MUTEXES_LOCK = Lock()
 
 try:
-    import fcntl
+    import portalocker
 except:
     pass # Ok if this fails, we can do without.
 
@@ -232,7 +232,7 @@ class SyncableAccount(Account):
 
         self._lockfd = open(self._lockfilepath, 'w')
         try:
-            fcntl.lockf(self._lockfd, fcntl.LOCK_EX|fcntl.LOCK_NB)
+            portalocker.lock(self._lockfd, portalocker.LOCK_EX)
         except NameError:
             #fcntl not available (Windows), disable file locking... :(
             pass
@@ -250,6 +250,7 @@ class SyncableAccount(Account):
 
         #If we own the lock file, delete it
         if self._lockfd and not self._lockfd.closed:
+            portalocker.unlock(self._lockfd)
             self._lockfd.close()
             try:
                 os.unlink(self._lockfilepath)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Requirements
 six
 gssapi[kerberos]
+portalocker


### PR DESCRIPTION
This PR use portalocker.lock() to replace fcntl.lockf() to support working on Windows in Cygwin