### PR TITLE
Return new_uid on copy message

### DIFF
--- a/offlineimap/folder/Base.py
+++ b/offlineimap/folder/Base.py
@@ -818,7 +818,7 @@ class BaseFolder(object):
         :param dstfolder: A BaseFolder-derived instance
         :param statusfolder: A LocalStatusFolder instance
         :param register: whether we should register a new thread."
-        :returns: Nothing on success, or raises an Exception."""
+        :returns: the new UID on success, or raises an Exception."""
 
         # Sometimes, it could be the case that if a sync takes awhile,
         # a message might be deleted from the maildir before it can be
@@ -863,9 +863,10 @@ class BaseFolder(object):
                 self.deletemessage(uid)
             else:
                 raise OfflineImapError("Trying to save msg (uid %d) on folder "
-                    "%s returned invalid uid %d"% (uid, dstfolder.getvisiblename(),
-                    new_uid), OfflineImapError.ERROR.MESSAGE)
         except (KeyboardInterrupt): # Bubble up CTRL-C.
+                                       "%s returned invalid uid %d" % (uid, dstfolder.getvisiblename(),
+                                                                       new_uid), OfflineImapError.ERROR.MESSAGE)
+            return new_uid
             raise
         except OfflineImapError as e:
             if e.severity > OfflineImapError.ERROR.MESSAGE:
@@ -941,7 +942,8 @@ class BaseFolder(object):
                     thread.start()
                     threads.append(thread)
                 else:
-                    self.copymessageto(uid, dstfolder, statusfolder, register=0)
+                    new_uid = self.copymessageto(
+                        uid, dstfolder, statusfolder, register=0)
             for thread in threads:
                 thread.join() # Block until all "copy" threads are done.
 

--- a/offlineimap/folder/Gmail.py
+++ b/offlineimap/folder/Gmail.py
@@ -280,13 +280,14 @@ class GmailFolder(IMAPFolder):
         :param dstfolder: A BaseFolder-derived instance
         :param statusfolder: A LocalStatusFolder instance
         :param register: whether we should register a new thread."
-        :returns: Nothing on success, or raises an Exception."""
+        :returns: the new UID on success, or raises an Exception."""
 
         # Check if we are really copying
         realcopy = uid > 0 and not dstfolder.uidexists(uid)
 
         # first copy the message
-        super(GmailFolder, self).copymessageto(uid, dstfolder, statusfolder, register)
+        new_uid = super(GmailFolder, self).copymessageto(
+            uid, dstfolder, statusfolder, register)
 
         # sync labels and mtime now when the message is new (the embedded labels are up to date)
         # otherwise we may be spending time for nothing, as they will get updated on a later pass.
@@ -299,6 +300,8 @@ class GmailFolder(IMAPFolder):
             # dstfolder is not GmailMaildir.
             except NotImplementedError:
                 return
+
+        return new_uid
 
     def syncmessagesto_labels(self, dstfolder, statusfolder):
         """Pass 4: Label Synchronization (Gmail only)

--- a/offlineimap/folder/GmailMaildir.py
+++ b/offlineimap/folder/GmailMaildir.py
@@ -208,8 +208,8 @@ class GmailMaildirFolder(MaildirFolder):
         :param uid: uid of the message to be copied.
         :param dstfolder: A BaseFolder-derived instance
         :param statusfolder: A LocalStatusFolder instance
-        :param register: whether we should register a new thread."
-        :returns: Nothing on success, or raises an Exception."""
+        :param register: whether we should register a new thread.
+        :returns: the new UID on success, or raises an Exception."""
 
         # Check if we are really copying.
         realcopy = uid > 0 and not dstfolder.uidexists(uid)
@@ -231,6 +231,8 @@ class GmailMaildirFolder(MaildirFolder):
             # dstfolder is not GmailMaildir.
             except NotImplementedError:
                 return
+
+        return new_uid
 
     def syncmessagesto_labels(self, dstfolder, statusfolder):
         """Pass 4: Label Synchronization (Gmail only)


### PR DESCRIPTION
In cases where the local UID > 0 but does not match the remote UID,
the `copymessageto()` function should return the new_uid so that
subsequent code can use it to look up the message in the message
cache.

Fixes: #613

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
