### PR TITLE
Implement Happy Eyeballs

### DIFF
--- a/offlineimap/imaplibutil.py
+++ b/offlineimap/imaplibutil.py
@@ -19,6 +19,7 @@ import fcntl
 import time
 import subprocess
 import threading
+import rfc6555
 import socket
 import errno
 import zlib
@@ -78,8 +79,15 @@ class UsefulIMAPMixIn(object):
     def open_socket(self):
         """open_socket()
         Open socket choosing first address family available."""
+        if self.af == socket.AF_UNSPEC:
+            # happy-eyeballs!
+            return rfc6555.create_connection((self.host, self.port))
+        else:
+            return self._open_socket_for_af(self.af)
+
+    def _open_socket_for_af(self, af):
         msg = (-1, 'could not open socket')
-        for res in socket.getaddrinfo(self.host, self.port, self.af, socket.SOCK_STREAM):
+        for res in socket.getaddrinfo(self.host, self.port, af, socket.SOCK_STREAM):
             af, socktype, proto, canonname, sa = res
             try:
                 # use socket of our own, possiblly socksified socket.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 six
 gssapi[kerberos]
 portalocker[cygwin]
+rfc6555


### PR DESCRIPTION
This allows OfflineIMAP to not stall on malfunctional IPv6 connections,
and fall-back to a functional IPv4 connection, if faster, as described
in RFC6665.

Signed-off-by: Olivier Mehani <shtrom@ssji.net>

> This v1.1 template stands in `.github/`.

### This PR

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [X] Code is tested (run OfflineIMAP with one such faulty connection, and saw a clean fallback to IPv4).