### PR TITLE
Don't expect trailing space on command completion

### DIFF
--- a/offlineimap/bundled_imaplib2.py
+++ b/offlineimap/bundled_imaplib2.py
@@ -342,7 +342,7 @@ class IMAP4(object):
         self.tagpre = Int2AP(random.randint(4096, 65535))
         self.tagre = re.compile(r'(?P<tag>'
                         + self.tagpre
-                        + r'\d+) (?P<type>[A-Z]+) (?P<data>.*)')
+                        + r'\d+) (?P<type>[A-Z]+) ?(?P<data>.*)')
 
         self._mode_ascii()	# Only option in py2
 


### PR DESCRIPTION
While trying to see why I couldn't get my emails from an Exchange server
I found this:

[imap]: 41:31.42 someserver.com handler _put_response(IOMC1 OK)
[imap]: 41:31.42 someserver.com handler unexpected response: 'IOMC1 OK'

And shortly after that the connection was closed. IOMC1 is just the
unique tag for the session.

The pattern looks for the tag, a number, a word like "OK" or something,
*then a space*, then optionally some data.

If the data aren't there it shouldn't be expecting a space.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


