### PR TITLE
Fixing the Arch Linux name

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Downloads releases as [tarball or zipball](https://github.com/OfflineIMAP/offlin
 If you are running Linux Os, you can install offlineimap with:
 
 -  openSUSE `zypper in offlineimap`
--  archLinux `pacman -S offlineimap`
+-  Arch Linux `pacman -S offlineimap`
 -  fedora `dnf install offlineimap`
 
 ## Feedbacks and contributions


### PR DESCRIPTION
according to the naming convention as described in the wiki:
https://wiki.archlinux.org/index.php/Arch_terminology#Arch_Linux

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

- Issue #no_space

### Additional information


