### PR TITLE
Only avoid remote folders, which contains localrepos separator

### DIFF
--- a/offlineimap/accounts.py
+++ b/offlineimap/accounts.py
@@ -395,9 +395,7 @@ class SyncableAccount(Account):
                 # their names since this would cause troubles while converting
                 # the name back (from local to remote).
                 sep = localrepos.getsep()
-                if (sep == os.path.sep or
-                    sep == remoterepos.getsep() or
-                    sep in remotefolder.getname()):
+                if sep in remotefolder.getname():
                     self.ui.warn('', "Ignoring folder '%s' due to unsupported "
                         "'%s' character serving as local separator."%
                         (remotefolder.getname(), localrepos.getsep()))


### PR DESCRIPTION
I remove the weird check on the separator itself to only keep the check
that the remote folder name does not contain the chosen local
separator. It must be the only case where troubles occur, as stated by
the above comment.

Signed-off-by: Étienne Deparis <etienne@depar.is>

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #640 

### Additional information

I've tested on my local configuration using a dedicated virtualenv. My config involves 4 different accounts, all using `/` as local separator and 2 using `/` as remote separator and 2 using `.` as remote separator.

Without these changes, the 7.3.1 offlineimap release does not sync anything, but with these changes, everything is working again as expected.
