### PR TITLE
Handle [ALREADYEXISTS] and Mailbox already exists!

### DIFF
--- a/offlineimap/repository/IMAP.py
+++ b/offlineimap/repository/IMAP.py
@@ -561,7 +561,8 @@ class IMAPRepository(BaseRepository):
             try:
                 self.makefolder_single(folder_path)
             except OfflineImapError as e:
-                if '[ALREADYEXISTS]' not in e.reason:
+                reasonLower = e.reason.lower()  # Handle reasons '[ALREADYEXISTS]' and 'Mailbox already exists!' @chris001
+                if not ('already' in reasonLower and 'exists' in reasonLower): 
                     raise
 
     def makefolder_single(self, foldername):


### PR DESCRIPTION
Make compatible with IMAP servers that give the reason code "[ALREADYEXISTS]" and IMAP servers that give natural language reason "Mailbox already exists!" by searching for the two words "already" and "exists" in the exception reason string.

> This v1.1 template stands in `.github/`.

### This PR

> Add character x `[x]`.

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).

### References

- Issue #645 

### Additional information

Tested for syntax by writing a few lines python program with this code and it ran fine.
