### PR TITLE
Add minimal deps in python package

### DIFF
--- a/offlineimap/__init__.py
+++ b/offlineimap/__init__.py
@@ -1,18 +1,17 @@
 __all__ = ['OfflineImap']
 
-__productname__ = 'OfflineIMAP'
-# Expecting trailing "-rcN" or "" for stable releases.
-__version__     = "7.3.3"
-__copyright__   = "Copyright 2002-2020 John Goerzen & contributors"
-__author__      = "John Goerzen"
-__author_email__= "offlineimap-project@lists.alioth.debian.org"
-__description__ = "Disconnected Universal IMAP Mail Synchronization/Reader Support"
-__license__  = "Licensed under the GNU GPL v2 or any later version (with an OpenSSL exception)"
-__bigcopyright__ = """%(__productname__)s %(__version__)s
-  %(__license__)s""" % locals()
-__homepage__ = "http://www.offlineimap.org"
-
-banner = __bigcopyright__
+from offlineimap.version import (
+        __productname__,
+        __version__,
+        __copyright__,
+        __author__,
+        __author_email__,
+        __description__,
+        __license__,
+        __bigcopyright__,
+        __homepage__,
+        banner
+        )
 
 from offlineimap.error import OfflineImapError
 # put this last, so we don't run into circular dependencies using

--- a/offlineimap/version.py
+++ b/offlineimap/version.py
@@ -1,0 +1,13 @@
+__productname__ = 'OfflineIMAP'
+# Expecting trailing "-rcN" or "" for stable releases.
+__version__     = "7.3.3"
+__copyright__   = "Copyright 2002-2020 John Goerzen & contributors"
+__author__      = "John Goerzen"
+__author_email__= "offlineimap-project@lists.alioth.debian.org"
+__description__ = "Disconnected Universal IMAP Mail Synchronization/Reader Support"
+__license__  = "Licensed under the GNU GPL v2 or any later version (with an OpenSSL exception)"
+__bigcopyright__ = """%(__productname__)s %(__version__)s
+  %(__license__)s""" % locals()
+__homepage__ = "http://www.offlineimap.org"
+
+banner = __bigcopyright__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# Requirements
-six
+# Minimal requirements defined in setup.py
+-e .
+# Extra "optional" requirements
 gssapi[kerberos]
 portalocker[cygwin]
-rfc6555

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,13 @@
 
 import os
 from distutils.core import setup, Command
-import offlineimap
 import logging
-from test.OLItest import TextTestRunner, TestLoader, OLITestLib
+
+from os import path
+here = path.abspath(path.dirname(__file__))
+
+# load __version__, __doc__, __author_, ...
+exec(open(path.join(here, 'offlineimap', 'version.py')).read())
 
 class TestCommand(Command):
     """runs the OLI testsuite"""
@@ -42,6 +46,11 @@ class TestCommand(Command):
         pass
 
     def run(self):
+        # Import the test classes here instead of at the begin of the module
+        # to avoid an implicit dependency of the 'offlineimap' module
+        # in the setup.py (which may run *before* offlineimap is installed)
+        from test.OLItest import TextTestRunner, TestLoader, OLITestLib
+
         logging.basicConfig(format='%(message)s')
         # set credentials and OfflineImap command to be executed:
         OLITestLib(cred_file='./test/credentials.conf', cmd='./offlineimap.py')
@@ -49,19 +58,18 @@ class TestCommand(Command):
         #TODO: failfast does not seem to exist in python2.6?
         TextTestRunner(verbosity=2,failfast=True).run(suite)
 
-
 setup(name = "offlineimap",
-      version = offlineimap.__version__,
-      description = offlineimap.__description__,
-      long_description = offlineimap.__description__,
-      author = offlineimap.__author__,
-      author_email = offlineimap.__author_email__,
-      url = offlineimap.__homepage__,
+      version = __version__,
+      description = __description__,
+      long_description = __description__,
+      author = __author__,
+      author_email = __author_email__,
+      url = __homepage__,
       packages = ['offlineimap', 'offlineimap.folder',
                   'offlineimap.repository', 'offlineimap.ui',
                   'offlineimap.utils'],
       scripts = ['bin/offlineimap'],
-      license = offlineimap.__copyright__ + \
+      license = __copyright__ + \
                 ", Licensed under the GPL version 2",
       cmdclass = { 'test': TestCommand}
 )

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,11 @@ class TestCommand(Command):
         #TODO: failfast does not seem to exist in python2.6?
         TextTestRunner(verbosity=2,failfast=True).run(suite)
 
+reqs = [
+    'six',
+    'rfc6555'
+    ]
+
 setup(name = "offlineimap",
       version = __version__,
       description = __description__,
@@ -71,6 +76,7 @@ setup(name = "offlineimap",
       scripts = ['bin/offlineimap'],
       license = __copyright__ + \
                 ", Licensed under the GPL version 2",
-      cmdclass = { 'test': TestCommand}
+      cmdclass = { 'test': TestCommand},
+      install_requires = reqs
 )
 


### PR DESCRIPTION
### This PR

Adds the minimal dependencies to the python package so they gets installed automatically by pip. Because the module offlineimap is used to get the metadata of the package (author, version), setup.py fails to import it if the dependencies are not installed before.

To avoid this circular dependency problem, the metadata was moved out to offlineimap/version.py.
This allows to run setup.py without requiring to have the dependencies (like what happens when you are installing it with pip)

> Add character x `[x]`.

- [X] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X] The relevant information about the changes stands in the commit message, not here in the message of the pull request.
- [X] Code changes follow the style of the files they change.
- [ ] Code is tested (provide details).

### References

- Issue #661
