### PR TITLE
Fix hooks for IDLE sync

### DIFF
--- a/offlineimap/imapserver.py
+++ b/offlineimap/imapserver.py
@@ -823,11 +823,12 @@ class IdleThread(object):
         statusrepos = account.statusrepos
         remotefolder = remoterepos.getfolder(self.folder, decode=False)
 
-        hook = account.getconf('presynchook', '')
-        account.callhook(hook)
+        hook_env = {
+            'OIMAP_ACCOUNT_NAME': account.getname(),
+        }
+        account.callhook('presynchook', hook_env)
         offlineimap.accounts.syncfolder(account, remotefolder, quick=False)
-        hook = account.getconf('postsynchook', '')
-        account.callhook(hook)
+        account.callhook('postsynchook', hook_env)
 
         ui = getglobalui()
         ui.unregisterthread(currentThread()) #syncfolder registered the thread


### PR DESCRIPTION
`presynchook` and `postsynchook` for IDLE-triggered syncs were broken by
da69fd8. This fixes them.

Signed-off-by: Reto Schnyder <reto.a.schnyder@bluewin.ch>

### This PR

- [x] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [x] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [x] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [x] Code changes follow the style of the files they change.
- [x] Code is tested (provide details).



