### PR TITLE
Lack of Python 3 support needs to be more clear..

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ Bugs, issues and contributions can be requested to both the mailing list or the
 
 ## Requirements & dependencies
 
-* Python v2.7+
+* Python v2.7.x
 * six (required)
 * rfc6555 (required)
 * imaplib2 >= 2.57 (optional)
 * gssapi (optional), for Kerberos authentication
 * portalocker (optional), if you need to run offlineimap in Cygwin for Windows
 
-* Python v3.4+ ***[STALLED] (experimental: [see known issues](https://github.com/OfflineIMAP/offlineimap/issues?q=is%3Aissue+is%3Aopen+label%3APy3))***
+* ~~Python v3.4+~~ ***[STALLED] (experimental: [see known issues](https://github.com/OfflineIMAP/offlineimap/issues?q=is%3Aissue+is%3Aopen+label%3APy3))***
 
 ## Documentation
 


### PR DESCRIPTION
I saw the top line, and the requirement for `six`, and took that to mean that Python 3 was supported. After wasting some of my time setting up and dealing with opaque bugs, I discovered that Python 3 is not supported after all.

"2.7+" implies modernity, so I'm suggesting we substitute "2.7.x" to be explicit that this is Python 2 only, and strike through the Python 3 line to be blunt that it is not working.
