### PR TITLE
Make offlineimap exit when run under python3

### DIFF
--- a/offlineimap.py
+++ b/offlineimap.py
@@ -18,7 +18,9 @@
 
 import os
 import sys
-
+if sys.version_info.major > 2:
+    print ("Offlineimap runs with python2 only. To use python 3, switch to using Offlineimap3")
+    sys.exit(1)
 from offlineimap import OfflineImap
 
 oi = OfflineImap()


### PR DESCRIPTION
It fails using python3, so notify the user about it.

- [X ] I've read the [DCO](http://www.offlineimap.org/doc/dco.html).
- [X ] I've read the [Coding Guidelines](http://www.offlineimap.org/doc/CodingGuidelines.html)
- [X ] The relevant informations about the changes stands in the commit message, not here in the message of the pull request.
- [X ] Code changes follow the style of the files they change.
- [X ] Code is tested (provide details).

### References

- Issue #714 

### Additional information


